### PR TITLE
Internalize TAP reporter and ditch “tap-parser”.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,3 +12,4 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run lint
+      - run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `--reporter=tap|auto` flag. `tap` is raw passthrough; `auto` (default)
+  adds ANSI colorization for TTY stdout and stays raw when piped.
+  Colorization never alters content — stripping the ANSI codes yields
+  byte-identical TAP (#7).
 - Added support for `playwright` as a `--client` option (#6).
 
 ### Changed
 
+- The `tap-parser` dependency is removed. It’s been replaced by a minimal,
+  internal implementation (#4).
 - Library moves to bring-your-own-browser. This means `puppeteer` moved from
   `dependencies` to `peerDependencies` with `optional: true` (#5).
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,16 @@ Required:
 Options:
   --coverage=<true|false>          Enable V8 JS coverage collection. Default: false.
   --test-name=<regex>              Filter tests by name (regex, matched against full name including describe chain).
+  --reporter=<tap|auto>            Output mode: 'tap' = raw passthrough; 'auto' = colorize when stdout is a TTY. Default: auto.
+
+Environment:
+  NO_COLOR                         Any non-empty value disables ANSI colorization (https://no-color.org).
+  FORCE_COLOR                      Any non-empty value forces ANSI colorization, even when stdout is not a TTY.
 
 Examples:
   x-test --client=puppeteer  --url=http://localhost:8080/test/
   x-test --client=puppeteer  --url=http://localhost:8080/test/ --coverage=true
+  x-test --client=puppeteer  --url=http://localhost:8080/test/ --reporter=tap | faucet
   x-test --client=playwright --url=http://localhost:8080/test/ --test-name='^render '
 ```
 
@@ -89,14 +95,24 @@ browser-side runner via the `x-test-name` URL query param.
 
 When `--coverage=true` and the browser exposes V8 coverage (Chromium does), the
 CLI collects coverage and hands it to the x-test root for processing.
-Playwright and Puppeteer emit coverage in different shapes; the CLI normalizes
-Playwright’s raw V8 output to Puppeteer’s `{text, ranges}` shape so the
-downstream x-test code sees identical input regardless of client.
+
+### Reporters
+
+The CLI emits TAP14 to stdout.
+
+- `--reporter=tap` — raw passthrough. Use this when piping to another TAP
+  consumer (CI log collectors, `faucet`, etc.).
+- `--reporter=auto` (default) — ANSI colorization when stdout is a TTY, raw when
+  piped. Stripping the ANSI codes yields byte-identical TAP, so the output is
+  safe for anything downstream even in auto mode.
+
+Colorization respects [`NO_COLOR`](https://no-color.org) and `FORCE_COLOR`
+environment variables.
 
 ### Exit code
 
-Non-zero if any test failed, the browser emitted a `Bail out!`, or the driver
-crashed. `0` otherwise.
+Non-zero if any test failed, the plan didn’t match the asserts seen,
+the browser emitted a `Bail out!`, or the driver crashed. `0` otherwise.
 
 ## Configuring Playwright
 

--- a/demo/color.js
+++ b/demo/color.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+// Pipe a TAP fixture through XTestCliTap with color forced on.
+//
+// Usage:  node demo/color.js <path/to/fixture.tap>
+
+import { readFileSync } from 'node:fs';
+import { XTestCliTap } from '../x-test-cli-tap.js';
+import { printHelp } from './help.js';
+
+const file = process.argv[2];
+if (!file) {
+  printHelp('demo:color');
+  process.exit(0);
+}
+
+const tap = new XTestCliTap({ stream: process.stdout, color: true });
+tap.write(readFileSync(file, 'utf8'));

--- a/demo/fixtures/bail.tap
+++ b/demo/fixtures/bail.tap
@@ -1,0 +1,4 @@
+TAP Version 14
+ok 1 - first test
+ok 2 - second test
+Bail out! database connection lost

--- a/demo/fixtures/basic.tap
+++ b/demo/fixtures/basic.tap
@@ -1,0 +1,5 @@
+TAP Version 14
+ok 1 - adds two numbers
+ok 2 - subtracts two numbers
+not ok 3 - divides by zero
+1..3

--- a/demo/fixtures/directives.tap
+++ b/demo/fixtures/directives.tap
@@ -1,0 +1,8 @@
+TAP Version 14
+ok 1 - normal pass
+ok 2 - not supported on this platform # SKIP
+not ok 3 - feature not built yet # TODO
+ok 4 - another pass
+ok 5 - quarantined for now # SKIP flaky
+ok 6 - surprise, this passed # TODO meant to fail
+1..6

--- a/demo/fixtures/nested.tap
+++ b/demo/fixtures/nested.tap
@@ -1,0 +1,20 @@
+TAP Version 14
+# Subtest: math
+    # Subtest: addition
+        ok 1 - 1 + 1 is 2
+        ok 2 - 0 + 0 is 0
+        1..2
+    ok 1 - addition
+    # Subtest: subtraction
+        ok 1 - 2 - 1 is 1
+        not ok 2 - 1 - 2 is -1 # TODO signed support
+        1..2
+    ok 2 - subtraction
+    1..2
+ok 1 - math
+# Subtest: strings
+    ok 1 - concat
+    ok 2 - length
+    1..2
+ok 2 - strings
+1..2

--- a/demo/fixtures/sample.tap
+++ b/demo/fixtures/sample.tap
@@ -1,0 +1,415 @@
+TAP version 14
+# Subtest: http://127.0.0.1:8080/test/
+    1..0
+ok 1 - http://127.0.0.1:8080/test/
+# Subtest: http://127.0.0.1:8080/test/test-reporter.html
+    # Subtest: render
+        ok 1 - prints out basic test
+        ok 2 - bails
+        1..2
+    ok 1 - render
+    # Subtest: parse
+        ok 1 - parses test
+        ok 2 - parses bail test
+        ok 3 - parses diagnostic
+        ok 4 - parses test line
+        ok 5 - parses "SKIP" test line
+        ok 6 - parses "TODO" test line
+        ok 7 - parses "not ok" test line
+        ok 8 - parses "not ok", "TODO" test line
+        ok 9 - parses version
+        ok 10 - parses in-failures bare URL as link
+        ok 11 - parses in-failures breadcrumb arrow as failure
+        ok 12 - parses in-failures yaml body as failure
+        ok 13 - tags in-failures blank separator as failure
+        ok 14 - leaves pre-failures diagnostics untouched
+        1..14
+    ok 2 - parse
+    1..2
+ok 2 - http://127.0.0.1:8080/test/test-reporter.html
+# Subtest: http://127.0.0.1:8080/test/test-suite.html
+    # Subtest: initialize
+        ok 1 - sets up default state and publishes when ready
+        ok 2 - marks state as bailed when any test bails
+        ok 3 - runs a test when told, ok
+        ok 4 - runs a test when told, skip
+        ok 5 - runs a test when told, not ok
+        ok 6 - runs a test when told, todo, ok
+        ok 7 - runs a test when told, todo, not ok
+        not ok 8 - closes registration after it is ready
+          ---
+          message: not ok
+          severity: fail
+          stack: |-
+            Error: not ok
+                at XTestSuite.assert (http://127.0.0.1:8080/x-test-suite.js:112:15)
+                at assert (http://127.0.0.1:8080/x-test.js:14:48)
+                at http://127.0.0.1:8080/test/test-suite.js:222:5
+                at async XTestSuite.onRun (http://127.0.0.1:8080/x-test-suite.js:63:27)
+          ...
+        1..8
+    not ok 1 - initialize
+    # Subtest: test
+        ok 1 - publishes new test
+        1..1
+    ok 2 - test
+    # Subtest: describe
+        ok 1 - publishes new describe-start and describe-end
+        ok 2 - respects current describe for multi-level nesting
+        ok 3 - publishes nested describe registered in callback
+        ok 4 - publishes nested it registered in callback
+        ok 5 - bails for failures during describe callback
+        ok 6 - throws if callback is not a function
+        1..6
+    ok 3 - describe
+    # Subtest: it
+        ok 1 - publishes new it
+        ok 2 - throws if “it” is not given a function as a callback
+        1..2
+    ok 4 - it
+    # Subtest: itSkip
+        ok 1 - publishes new skip
+        1..1
+    ok 5 - itSkip
+    # Subtest: itTodo
+        ok 1 - publishes new todo
+        1..1
+    ok 6 - itTodo
+    # Subtest: itOnly
+        ok 1 - publishes new only
+        1..1
+    ok 7 - itOnly
+    # Subtest: register
+        # Subtest: coverage
+            ok 1 - publishes new coverage
+            ok 2 - throws for bad goal value
+            1..2
+        ok 1 - coverage
+        1..1
+    ok 8 - register
+    # Subtest: waitFor
+        ok 1 - adds a promise when called
+        ok 2 - publishes "x-test-ready" when resolved
+        ok 3 - awaits resolution of all promises to publish "x-test-ready"
+        1..3
+    ok 9 - waitFor
+    # Subtest: bail
+        ok 1 - marks state as ended
+        ok 2 - publishes to parent frame
+        1..2
+    ok 10 - bail
+    # Subtest: error
+        ok 1 - turns error into basic object
+        ok 2 - handles string errors
+        1..2
+    ok 11 - error
+    1..11
+not ok 3 - http://127.0.0.1:8080/test/test-suite.html
+# Subtest: http://127.0.0.1:8080/test/test-root.html
+    # Subtest: level
+        ok 1 - returns level = 1 for "test-plan"
+        ok 2 - returns level = 0 for "test-start"
+        ok 3 - returns level = 0 for "test-end"
+        ok 4 - returns level = 0 for "coverage"
+        ok 5 - returns level for "describe-plan" # SKIP
+        ok 6 - returns level for "describe-start" # SKIP
+        ok 7 - returns level for "describe-end" # SKIP
+        ok 8 - returns level for "it" # SKIP
+        1..8
+    ok 1 - level
+    # Subtest: count
+        ok 1 - returns count for "test-plan"
+        ok 2 - returns count for "describe-plan"
+        ok 3 - returns count for "exit"
+        1..3
+    ok 2 - count
+    # Subtest: yaml
+        ok 1 - finds the given "it" step and returns a yaml object
+        1..1
+    ok 3 - yaml
+    # Subtest: end
+        ok 1 - marks state as ended
+        ok 2 - marks waiting as false
+        ok 3 - publishes that the test has ended
+        1..3
+    ok 4 - end
+    # Subtest: analyzeHrefCoverage
+        ok 1 - test coverage
+        1..1
+    ok 5 - analyzeHrefCoverage
+    # Subtest: collectFailureStepIds
+        ok 1 - returns failing it step ids in order, excluding TODO and passing
+        ok 2 - does not include failing coverage steps
+        1..2
+    ok 6 - collectFailureStepIds
+    # Subtest: formatFailure
+        ok 1 - formats a failing "it" with arrow-joined breadcrumb and raw stack
+        ok 2 - falls back to "Error: <message>" when stack is missing
+        1..2
+    ok 7 - formatFailure
+    1..7
+ok 4 - http://127.0.0.1:8080/test/test-root.html
+# Subtest: http://127.0.0.1:8080/test/test-tap.html
+    # Subtest: version
+        ok 1 - renders "TAP version 14"
+        1..1
+    ok 1 - version
+    # Subtest: diagnostic
+        ok 1 - basic
+        ok 2 - basic, indented
+        ok 3 - multiline
+        ok 4 - multiline, indented
+        1..4
+    ok 2 - diagnostic
+    # Subtest: testLine
+        ok 1 - basic, passing
+        ok 2 - basic, passing, indented
+        ok 3 - basic, failing
+        ok 4 - basic, failing, indented
+        ok 5 - multiline
+        ok 6 - multiline, indented
+        ok 7 - skip
+        ok 8 - skip, indented
+        ok 9 - todo, passing
+        ok 10 - todo, passing, indented
+        ok 11 - todo, failing
+        ok 12 - todo, failing, indented
+        1..12
+    ok 3 - testLine
+    # Subtest: subtest
+        ok 1 - basic
+        ok 2 - basic, indented
+        1..2
+    ok 4 - subtest
+    # Subtest: yaml
+        ok 1 - basic
+        ok 2 - indented
+        1..2
+    ok 5 - yaml
+    # Subtest: bailOut
+        ok 1 - basic
+        ok 2 - without message
+        1..2
+    ok 6 - bailOut
+    # Subtest: plan
+        ok 1 - basic
+        1..1
+    ok 7 - plan
+    1..7
+ok 5 - http://127.0.0.1:8080/test/test-tap.html
+# Subtest: http://127.0.0.1:8080/test/test-common.html
+    # Subtest: timeout
+        ok 1 - resolves with XTestCommon.TIMEOUT after the interval
+        1..1
+    ok 1 - timeout
+    # Subtest: domContentLoadedPromise
+        ok 1 - resolves immediately when readyState is "complete"
+        ok 2 - resolves on DOMContentLoaded when readyState is not "complete"
+        1..2
+    ok 2 - domContentLoadedPromise
+    # Subtest: iframeError
+        ok 1 - resolves with XTestCommon.IFRAME_ERROR when the error event fires
+        1..1
+    ok 3 - iframeError
+    # Subtest: iframeLoad
+        ok 1 - resolves with XTestCommon.IFRAME_LOAD when the load event fires
+        1..1
+    ok 4 - iframeLoad
+    1..4
+ok 6 - http://127.0.0.1:8080/test/test-common.html
+# Subtest: http://127.0.0.1:8080/test/test-boot.html
+    # Subtest: <script type="module"> in <head>
+        ok 1 - registers into the same suite as body-placed scripts
+        1..1
+    ok 1 - <script type="module"> in <head>
+    # Subtest: first <script type="module"> in <body>
+        ok 1 - registers tests
+        1..1
+    ok 2 - first <script type="module"> in <body>
+    # Subtest: second <script type="module"> in <body>
+        not ok 1 - is not silently dropped after the first script evaluates
+          ---
+          message: not ok
+          severity: fail
+          stack: |-
+            Error: not ok
+                at XTestSuite.assert (http://127.0.0.1:8080/x-test-suite.js:112:15)
+                at assert (http://127.0.0.1:8080/x-test.js:14:48)
+                at http://127.0.0.1:8080/test/test-boot-c.js:5:5
+                at XTestSuite.onRun (http://127.0.0.1:8080/x-test-suite.js:63:47)
+                at http://127.0.0.1:8080/x-test-suite.js:19:22
+                at BroadcastChannel.<anonymous> (http://127.0.0.1:8080/x-test.js:143:5)
+          ...
+        1..1
+    not ok 3 - second <script type="module"> in <body>
+    # Subtest: inline <script type="module">
+        ok 1 - registers alongside src-backed scripts
+        1..1
+    ok 4 - inline <script type="module">
+    1..4
+not ok 7 - http://127.0.0.1:8080/test/test-boot.html
+# Subtest: http://127.0.0.1:8080/test/test-scratch.html
+    # Subtest: this wrapper exercises describe only logic
+        # Subtest: this wrapper exercises describe skip logic
+            ok 1 - this tests shows inheritance of outer grouping skip directive # SKIP
+            not ok 2 - this tests that inner flags override outer ones
+              ---
+              message: not ok
+              severity: fail
+              stack: |-
+                Error: not ok
+                    at XTestSuite.assert (http://127.0.0.1:8080/x-test-suite.js:112:15)
+                    at assert (http://127.0.0.1:8080/x-test.js:14:48)
+                    at http://127.0.0.1:8080/test/test-scratch.js:9:7
+                    at XTestSuite.onRun (http://127.0.0.1:8080/x-test-suite.js:63:47)
+                    at http://127.0.0.1:8080/x-test-suite.js:19:22
+                    at BroadcastChannel.<anonymous> (http://127.0.0.1:8080/x-test.js:143:5)
+              ...
+            1..2
+        not ok 1 - this wrapper exercises describe skip logic
+        # Subtest: this wrapper exercises describe todo logic
+            not ok 1 - this tests shows inheritance of outer grouping todo directive # TODO
+              ---
+              message: this error is expected
+              severity: todo
+              stack: |-
+                Error: this error is expected
+                    at XTestSuite.assert (http://127.0.0.1:8080/x-test-suite.js:112:15)
+                    at assert (http://127.0.0.1:8080/x-test.js:14:48)
+                    at http://127.0.0.1:8080/test/test-scratch.js:14:7
+                    at XTestSuite.onRun (http://127.0.0.1:8080/x-test-suite.js:63:47)
+                    at http://127.0.0.1:8080/x-test-suite.js:19:22
+                    at BroadcastChannel.<anonymous> (http://127.0.0.1:8080/x-test.js:143:5)
+              ...
+            1..1
+        ok 2 - this wrapper exercises describe todo logic
+        ok 3 - this simply exercises the skip logic for coverage # SKIP
+        # Subtest: this wrapper allows inner tests to declare their own flags
+            not ok 1 - this simply exercises the todo logic for coverage # TODO
+              ---
+              message: this error is expected
+              severity: todo
+              stack: |-
+                Error: this error is expected
+                    at XTestSuite.assert (http://127.0.0.1:8080/x-test-suite.js:112:15)
+                    at assert (http://127.0.0.1:8080/x-test.js:14:48)
+                    at http://127.0.0.1:8080/test/test-scratch.js:22:7
+                    at XTestSuite.onRun (http://127.0.0.1:8080/x-test-suite.js:63:47)
+                    at http://127.0.0.1:8080/x-test-suite.js:19:22
+                    at BroadcastChannel.<anonymous> (http://127.0.0.1:8080/x-test.js:143:5)
+              ...
+            ok 2 - this simply exercises the only logic for coverage
+            1..2
+        ok 4 - this wrapper allows inner tests to declare their own flags
+        1..4
+    not ok 1 - this wrapper exercises describe only logic
+    # Subtest: interval
+        not ok 1 - times out after interval - this is supposed to fail # TODO
+          ---
+          message: timeout after 0ms
+          severity: todo
+          stack: |-
+            Error: timeout after 0ms
+                at XTestSuite.onRun (http://127.0.0.1:8080/x-test-suite.js:65:19)
+          ...
+        1..1
+    ok 2 - interval
+    ok 3 - asynchronously registered tests work
+    1..3
+not ok 8 - http://127.0.0.1:8080/test/test-scratch.html
+not ok 9 - 75% coverage goal for http://127.0.0.1:8080/x-test-reporter.js (got 74.88%)
+# 1       |  import styleSheet from './x-test-reporter.css.js';
+# …
+# 35      |      if (!el) {
+# 36 !    |        throw new Error(`Expected ${id} to exist.`);
+# 37 !    |      }
+# 38      |      if (el.tagName.toLowerCase() !== expectedTag) {
+# 39 !    |        throw new Error(`Expected ${id} to be <${expectedTag}>, got <${el.tagName.toLowerCase()}>`);
+# 40 !    |      }
+# …
+# 47      |      if (!this.shadowRoot) {
+# 48 !    |        throw new Error('Shadow root must exist after attachShadow');
+# 49 !    |      }
+# …
+# 70      |      this.#references.toggle.addEventListener('click', () => {
+# 71 !    |        this.hasAttribute('open') ? this.removeAttribute('open') : this.setAttribute('open', '');
+# 72 !    |        localStorage.setItem('x-test-reporter-closed', String(!this.hasAttribute('open')));
+# 73 !    |      });
+# …
+# 77      |      const resize = (event) => {
+# 78 !    |        const nextHeaderY = event.clientY - Number(this.getAttribute('dragging'));
+# …
+# 82 !    |        localStorage.setItem('x-test-reporter-height', this.style.height);
+# 83 !    |      };
+# 84      |      this.#references.form.addEventListener('reset', () => {
+# 85 !    |        const url = new URL(location.href);
+# 86 !    |        url.searchParams.delete('x-test-name');
+# 87 !    |        location.href = url.href;
+# 88 !    |      });
+# …
+# 92      |      const handleSubmit = (event) => {
+# 93 !    |        event.preventDefault();
+# …
+# 102 !   |        location.href = url.href;
+# 103 !   |      };
+# …
+# 108     |      const handlePointerDown = (event) => {
+# 109 !   |        if (this.hasAttribute('open')) {
+# …
+# 117 !   |        }
+# 118 !   |      };
+# 119     |      this.#references.header.addEventListener('pointerdown', handlePointerDown);
+# 120     |      addEventListener('pointerup', () => {
+# 121 !   |        removeEventListener('pointermove', resize);
+# …
+# 125 !   |        }
+# 126 !   |      });
+# …
+# 135     |        if (text === '# Failures:') {
+# 136 !   |          this.#inFailures = true;
+# 137 !   |        }
+# …
+# 211     |        } else if (text.match(/^(?: {4})*Bail out!.*/)) {
+# 212 !   |          result.attributes.bail = '';
+# 213 !   |          result.failed = true;
+# 214 !   |        }
+# …
+# 229     |  
+ok 10 - 71% coverage goal for http://127.0.0.1:8080/x-test-root.js (got 75.18%)
+ok 11 - 96% coverage goal for http://127.0.0.1:8080/x-test-suite.js (got 96.56%)
+ok 12 - 100% coverage goal for http://127.0.0.1:8080/x-test-tap.js (got 100.00%)
+ok 13 - 100% coverage goal for http://127.0.0.1:8080/x-test.js (got 100.00%)
+1..13
+# Failures:
+# 
+# http://127.0.0.1:8080/test/test-suite.html
+# > initialize
+# > closes registration after it is ready
+# Error: not ok
+#     at XTestSuite.assert (http://127.0.0.1:8080/x-test-suite.js:112:15)
+#     at assert (http://127.0.0.1:8080/x-test.js:14:48)
+#     at http://127.0.0.1:8080/test/test-suite.js:222:5
+#     at async XTestSuite.onRun (http://127.0.0.1:8080/x-test-suite.js:63:27)
+# 
+# http://127.0.0.1:8080/test/test-boot.html
+# > second <script type="module"> in <body>
+# > is not silently dropped after the first script evaluates
+# Error: not ok
+#     at XTestSuite.assert (http://127.0.0.1:8080/x-test-suite.js:112:15)
+#     at assert (http://127.0.0.1:8080/x-test.js:14:48)
+#     at http://127.0.0.1:8080/test/test-boot-c.js:5:5
+#     at XTestSuite.onRun (http://127.0.0.1:8080/x-test-suite.js:63:47)
+#     at http://127.0.0.1:8080/x-test-suite.js:19:22
+#     at BroadcastChannel.<anonymous> (http://127.0.0.1:8080/x-test.js:143:5)
+# 
+# http://127.0.0.1:8080/test/test-scratch.html
+# > this wrapper exercises describe only logic
+# > this wrapper exercises describe skip logic
+# > this tests that inner flags override outer ones
+# Error: not ok
+#     at XTestSuite.assert (http://127.0.0.1:8080/x-test-suite.js:112:15)
+#     at assert (http://127.0.0.1:8080/x-test.js:14:48)
+#     at http://127.0.0.1:8080/test/test-scratch.js:9:7
+#     at XTestSuite.onRun (http://127.0.0.1:8080/x-test-suite.js:63:47)
+#     at http://127.0.0.1:8080/x-test-suite.js:19:22
+#     at BroadcastChannel.<anonymous> (http://127.0.0.1:8080/x-test.js:143:5)

--- a/demo/help.js
+++ b/demo/help.js
@@ -1,0 +1,36 @@
+import { readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const COMMANDS = {
+  'demo:color': 'Colorize a TAP fixture (ANSI output)',
+  'demo:tap':   'Pass a fixture through raw (byte-identical)',
+};
+
+function listFixtures() {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return readdirSync(join(here, 'fixtures'))
+    .filter(f => f.endsWith('.tap'))
+    .sort()
+    .map(f => `demo/fixtures/${f}`);
+}
+
+/**
+ * Print demo help. With no argument: list the demo commands (copy-pasteable
+ * as-is to drill in). With a command name: list one copy-pasteable command
+ * per fixture.
+ */
+export function printHelp(command) {
+  if (command && COMMANDS[command]) {
+    process.stdout.write(`${COMMANDS[command]}\n\n`);
+    for (const f of listFixtures()) {
+      process.stdout.write(`  npm run ${command} -- ${f}\n`);
+    }
+    return;
+  }
+
+  process.stdout.write('Demos:\n\n');
+  for (const name of Object.keys(COMMANDS)) {
+    process.stdout.write(`  npm run ${name}\n`);
+  }
+}

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+// `npm run demo` — print the list of demo scripts and fixtures.
+
+import { printHelp } from './help.js';
+printHelp();

--- a/demo/tap.js
+++ b/demo/tap.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+// Pipe a TAP fixture through XTestCliTap with color off (raw passthrough).
+// Output should be byte-identical to the fixture.
+//
+// Usage:  node demo/tap.js <path/to/fixture.tap>
+
+import { readFileSync } from 'node:fs';
+import { XTestCliTap } from '../x-test-cli-tap.js';
+import { printHelp } from './help.js';
+
+const file = process.argv[2];
+if (!file) {
+  printHelp('demo:tap');
+  process.exit(0);
+}
+
+const tap = new XTestCliTap({ stream: process.stdout, color: false });
+tap.write(readFileSync(file, 'utf8'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@netflix/x-test-cli",
       "version": "1.0.0-rc.2",
       "license": "Apache-2.0",
-      "dependencies": {
-        "tap-parser": ">=18.0.0"
-      },
       "bin": {
         "x-test": "x-test-cli.js"
       },
@@ -600,15 +597,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/events-to-array": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-2.0.3.tgz",
-      "integrity": "sha512-f/qE2gImHRa4Cp2y1stEOSgw8wTFyUdVJX7G//bMwbaV9JqISFxg99NbmVQeP7YLnDUZ2un851jlaDrlpmGehQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1054,35 +1042,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tap-parser": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-18.3.3.tgz",
-      "integrity": "sha512-dPcpxuYdaN1uEwYGJ5eJSc+XzkJBzgnlhGkxoAhVGjuEMpiGh4e305Z4pVZXFSMYZGoRnD211c45HeYygVa6Cg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "events-to-array": "^2.0.3",
-        "tap-yaml": "4.4.1"
-      },
-      "bin": {
-        "tap-parser": "bin/cmd.cjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/tap-yaml": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-4.4.1.tgz",
-      "integrity": "sha512-SEcvFLmY731oUBGGhRKdkb+Ebk1F101PFHdKdO///1SeO4FqWl1x1vnrgvxLtSS9qhs0hp7Ca2r4lXhwmiUi2g==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "yaml": "^2.8.3",
-        "yaml-types": "^0.4.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -1130,34 +1089,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/yaml-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/yaml-types/-/yaml-types-0.4.0.tgz",
-      "integrity": "sha512-XfbA30NUg4/LWUiplMbiufUiwYhgB9jvBhTWel7XQqjV+GaB79c2tROu/8/Tu7jO0HvDvnKWtBk5ksWRrhQ/0g==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 16",
-        "npm": ">= 7"
-      },
-      "peerDependencies": {
-        "yaml": "^2.3.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -18,16 +18,21 @@
   "scripts": {
     "lint": "eslint --max-warnings=0 .",
     "lint-fix": "eslint --fix .",
+    "test": "node --test test/*.test.js",
+    "demo": "node demo/index.js",
+    "demo:color": "node demo/color.js",
+    "demo:tap": "node demo/tap.js",
     "bump": "./bump.sh"
   },
   "files": [
     "LICENSE",
     "/x-test-cli.js",
-    "/x-test-cli-browser.js"
+    "/x-test-cli-browser.js",
+    "/x-test-cli-tap.js",
+    "/test",
+    "/demo"
   ],
-  "dependencies": {
-    "tap-parser": ">=18.0.0"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "puppeteer": ">=20.0.0",
     "playwright": ">=1.40.0"

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -1,0 +1,73 @@
+import { suite, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { XTestCliBrowserPlaywright } from '../x-test-cli-browser.js';
+
+suite('XTestCliBrowserPlaywright.normalizeCoverage', () => {
+  test('maps source->text and preserves url/scriptId', () => {
+    const input = [{
+      url: 'http://example/a.js',
+      scriptId: '1',
+      source: 'const x = 1;',
+      functions: [],
+    }];
+    const [entry] = XTestCliBrowserPlaywright.normalizeCoverage(input);
+    assert.equal(entry.url, 'http://example/a.js');
+    assert.equal(entry.scriptId, '1');
+    assert.equal(entry.text, 'const x = 1;');
+    assert.deepEqual(entry.ranges, []);
+  });
+
+  test('flattens ranges with count > 0', () => {
+    const input = [{
+      url: 'u', scriptId: 's', source: 'abcdefghij',
+      functions: [
+        { ranges: [{ startOffset: 0, endOffset: 5, count: 1 }] },
+        { ranges: [{ startOffset: 5, endOffset: 10, count: 2 }] },
+      ],
+    }];
+    const [entry] = XTestCliBrowserPlaywright.normalizeCoverage(input);
+    assert.deepEqual(entry.ranges, [
+      { start: 0, end: 5 },
+      { start: 5, end: 10 },
+    ]);
+  });
+
+  test('drops ranges with count === 0', () => {
+    const input = [{
+      url: 'u', scriptId: 's', source: 'src',
+      functions: [
+        { ranges: [
+          { startOffset: 0, endOffset: 10, count: 1 },
+          { startOffset: 3, endOffset: 7, count: 0 },
+        ] },
+      ],
+    }];
+    const [entry] = XTestCliBrowserPlaywright.normalizeCoverage(input);
+    assert.deepEqual(entry.ranges, [{ start: 0, end: 10 }]);
+  });
+
+  test('handles missing functions array', () => {
+    const input = [{ url: 'u', scriptId: 's', source: 'x' }];
+    const [entry] = XTestCliBrowserPlaywright.normalizeCoverage(input);
+    assert.deepEqual(entry.ranges, []);
+  });
+
+  test('handles empty input', () => {
+    assert.deepEqual(XTestCliBrowserPlaywright.normalizeCoverage([]), []);
+  });
+
+  test('handles multiple entries independently', () => {
+    const input = [
+      { url: 'a', scriptId: '1', source: 'a', functions: [
+        { ranges: [{ startOffset: 0, endOffset: 1, count: 1 }] },
+      ] },
+      { url: 'b', scriptId: '2', source: 'bb', functions: [
+        { ranges: [{ startOffset: 0, endOffset: 2, count: 0 }] },
+      ] },
+    ];
+    const out = XTestCliBrowserPlaywright.normalizeCoverage(input);
+    assert.equal(out.length, 2);
+    assert.deepEqual(out[0].ranges, [{ start: 0, end: 1 }]);
+    assert.deepEqual(out[1].ranges, []);
+  });
+});

--- a/test/tap.test.js
+++ b/test/tap.test.js
@@ -1,0 +1,888 @@
+import { suite, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { PassThrough } from 'node:stream';
+import { XTestCliTap } from '../x-test-cli-tap.js';
+
+function stripAnsi(string) {
+  // eslint-disable-next-line no-control-regex
+  return string.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+// Named ANSI styles — used to build the expected stylized output of the
+//  reporter so tests can compare byte-for-byte instead of writing regexes
+//  per line. Mirrors `XTestCliTap.#styles`.
+const styles = {
+  reset:   '\x1b[0m',
+  dim:     '\x1b[2m',
+  boldRed: '\x1b[1;31m',
+  red:     '\x1b[31m',
+  green:   '\x1b[32m',
+  yellow:  '\x1b[33m',
+  orange:  '\x1b[38;5;208m',
+  cyan:    '\x1b[36m',
+};
+
+/** Strips common leading indentation from a tagged template literal. */
+function dedent(strings, ...values) {
+  let raw = strings[0];
+  for (let index = 0; index < values.length; index++) {
+    raw += String(values[index]) + strings[index + 1];
+  }
+  const lines = raw.split('\n');
+  if (lines.length > 0 && lines[0].trim() === '') {
+    lines.shift();
+  }
+  if (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+    lines.pop();
+  }
+  let minIndent = Infinity;
+  for (const line of lines) {
+    if (line.trim() === '') {
+      continue;
+    }
+    const indent = line.match(/^(\s*)/)?.[0].length ?? 0;
+    if (indent < minIndent) {
+      minIndent = indent;
+    }
+  }
+  if (minIndent > 0 && minIndent < Infinity) {
+    return lines.map(line => line.slice(minIndent) + '\n').join('');
+  }
+  return lines.map(line => line + '\n').join('');
+}
+
+suite('result accumulation', () => {
+  test('plan + passes → ok', () => {
+    const text = dedent`
+      TAP version 14
+      1..2
+      ok 1 - a
+      ok 2 - b
+    `;
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write(text);
+    tap.end();
+    assert.deepEqual(tap.result, {
+      ok: true,
+      pass: 2,
+      fail: 0,
+      skip: 0,
+      todo: 0,
+      count: 2,
+      plan: { start: 1, end: 2 },
+      bailed: false,
+      bailReason: null,
+    });
+  });
+
+  test('not ok → fail, overall not ok', () => {
+    const text = dedent`
+      1..1
+      not ok 1 - broken
+    `;
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write(text);
+    tap.end();
+    assert.deepEqual(tap.result, {
+      ok: false,
+      pass: 0,
+      fail: 1,
+      skip: 0,
+      todo: 0,
+      count: 1,
+      plan: { start: 1, end: 1 },
+      bailed: false,
+      bailReason: null,
+    });
+  });
+
+  test('plan mismatch → not ok', () => {
+    const text = dedent`
+      1..3
+      ok 1
+      ok 2
+    `;
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write(text);
+    tap.end();
+    assert.deepEqual(tap.result, {
+      ok: false,
+      pass: 2,
+      fail: 0,
+      skip: 0,
+      todo: 0,
+      count: 2,
+      plan: { start: 1, end: 3 },
+      bailed: false,
+      bailReason: null,
+    });
+  });
+
+  test('1..0 is a valid "empty run" and stays ok', () => {
+    const text = dedent`
+      1..0
+    `;
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write(text);
+    tap.end();
+    assert.deepEqual(tap.result, {
+      ok: true,
+      pass: 0,
+      fail: 0,
+      skip: 0,
+      todo: 0,
+      count: 0,
+      plan: { start: 1, end: 0 },
+      bailed: false,
+      bailReason: null,
+    });
+  });
+
+  test('1..0 followed by asserts → not ok (plan mismatch)', () => {
+    const text = dedent`
+      1..0
+      ok 1 - surprise
+    `;
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write(text);
+    tap.end();
+    assert.deepEqual(tap.result, {
+      ok: false,
+      pass: 1,
+      fail: 0,
+      skip: 0,
+      todo: 0,
+      count: 1,
+      plan: { start: 1, end: 0 },
+      bailed: false,
+      bailReason: null,
+    });
+  });
+
+  test('nested subtest asserts do not inflate top-level count', () => {
+    const text = dedent`
+      TAP version 14
+      # Subtest: group
+          ok 1 - inner1
+          ok 2 - inner2
+          1..2
+      ok 1 - group
+      1..1
+    `;
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write(text);
+    tap.end();
+    const result = tap.result;
+    // Only the top-level `ok 1 - group` should count. The inner asserts
+    //  are rendered but ignored for plan-vs-count validation (they're
+    //  the producer's concern; our scanner trusts the rollup).
+    assert.deepEqual(result, {
+      ok: true,
+      pass: 1,
+      fail: 0,
+      skip: 0,
+      todo: 0,
+      count: 1,
+      plan: { start: 1, end: 1 },
+      bailed: false,
+      bailReason: null,
+    });
+  });
+
+  test('inner plan does not overwrite top-level plan', () => {
+    const text = dedent`
+      # Subtest: group
+          ok 1 - inner
+          1..1
+      ok 1 - group
+      1..1
+    `;
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write(text);
+    tap.end();
+    assert.deepEqual(tap.result, {
+      ok: true,
+      pass: 1,
+      fail: 0,
+      skip: 0,
+      todo: 0,
+      count: 1,
+      plan: { start: 1, end: 1 },
+      bailed: false,
+      bailReason: null,
+    });
+  });
+
+  test('realistic x-test-style output: deeply nested subtests report ok', () => {
+    // Mirrors the shape of real x-test output: multiple top-level URL
+    //  subtests, each with inner describe-blocks, each with inner
+    //  asserts and inner plans. The top-level plan (1..2) should match
+    //  the count of top-level rollup asserts (2), regardless of how
+    //  many nested asserts there are.
+    const text = dedent`
+      TAP version 14
+      # Subtest: http://host/a/
+          1..0
+      ok 1 - http://host/a/
+      # Subtest: http://host/b/
+          # Subtest: describe-block
+              ok 1 - inner a
+              ok 2 - inner b
+              ok 3 - inner c
+              1..3
+          ok 1 - describe-block
+          # Subtest: another
+              ok 1 - deep1
+              ok 2 - deep2
+              1..2
+          ok 2 - another
+          1..2
+      ok 2 - http://host/b/
+      1..2
+    `;
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write(text);
+    tap.end();
+    assert.deepEqual(tap.result, {
+      ok: true,
+      pass: 2,
+      fail: 0,
+      skip: 0,
+      todo: 0,
+      count: 2,
+      plan: { start: 1, end: 2 },
+      bailed: false,
+      bailReason: null,
+    });
+  });
+
+  test('bail → not ok, captures reason', () => {
+    const text = dedent`
+      Bail out! launch timeout
+    `;
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write(text);
+    tap.end();
+    assert.deepEqual(tap.result, {
+      ok: false,
+      pass: 0,
+      fail: 0,
+      skip: 0,
+      todo: 0,
+      count: 0,
+      plan: null,
+      bailed: true,
+      bailReason: 'launch timeout',
+    });
+  });
+
+  test('ok with description but no dash still parses', () => {
+    const text = dedent`
+      1..1
+      ok 1 plain description
+    `;
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write(text);
+    tap.end();
+    assert.deepEqual(tap.result, {
+      ok: true,
+      pass: 1,
+      fail: 0,
+      skip: 0,
+      todo: 0,
+      count: 1,
+      plan: { start: 1, end: 1 },
+      bailed: false,
+      bailReason: null,
+    });
+  });
+
+  test('ok without number or description still counts', () => {
+    const text = dedent`
+      1..1
+      ok
+    `;
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write(text);
+    tap.end();
+    assert.deepEqual(tap.result, {
+      ok: true,
+      pass: 1,
+      fail: 0,
+      skip: 0,
+      todo: 0,
+      count: 1,
+      plan: { start: 1, end: 1 },
+      bailed: false,
+      bailReason: null,
+    });
+  });
+});
+
+suite('directives', () => {
+  test('TODO on not ok does not count as failure', () => {
+    const text = dedent`
+      1..1
+      not ok 1 - pending # TODO later
+    `;
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write(text);
+    tap.end();
+    assert.deepEqual(tap.result, {
+      ok: true,
+      pass: 0,
+      fail: 0,
+      skip: 0,
+      todo: 1,
+      count: 1,
+      plan: { start: 1, end: 1 },
+      bailed: false,
+      bailReason: null,
+    });
+  });
+
+  test('SKIP on ok is counted as skip', () => {
+    const text = dedent`
+      1..1
+      ok 1 - feature # SKIP not supported
+    `;
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write(text);
+    tap.end();
+    assert.deepEqual(tap.result, {
+      ok: true,
+      pass: 0,
+      fail: 0,
+      skip: 1,
+      todo: 0,
+      count: 1,
+      plan: { start: 1, end: 1 },
+      bailed: false,
+      bailReason: null,
+    });
+  });
+
+});
+
+suite('passthrough (color off) is byte-identical', () => {
+  test('non-yaml lines emit unchanged', () => {
+    const text = dedent`
+      TAP version 14
+      ok 1 - alpha
+      not ok 2 - beta # TODO later
+      ok 3 - gamma # SKIP because
+      # Subtest: render
+          ok 1 - inner
+          1..1
+      ok 4 - render
+      Bail out! bad
+      1..4
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: false });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === text);
+  });
+
+  test('yaml blocks emit unchanged (no dimming when color off)', () => {
+    const text = dedent`
+      not ok 1 - boom
+        ---
+        message: it broke
+        stack: trace
+        ...
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: false });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === text);
+  });
+
+  test('stripping ANSI from color-on output yields byte-identical input', () => {
+    const text = dedent`
+      TAP version 14
+      ok 1 - a
+      not ok 2 - b # TODO later
+      ok 3 - c # SKIP nope
+        ---
+        body
+        ...
+      Bail out! reason
+      1..3
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(stripAnsi(out) === text);
+  });
+});
+
+suite('colorization', () => {
+  test('ok → green whole line', () => {
+    const text = dedent`
+      ok 1 - alpha
+    `;
+    const stylized = dedent`
+      ${styles.green}ok 1 - alpha${styles.reset}
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === stylized);
+    assert(stripAnsi(out) === text);
+  });
+
+  test('not ok → red whole line', () => {
+    const text = dedent`
+      not ok 2 - boom
+    `;
+    const stylized = dedent`
+      ${styles.red}not ok 2 - boom${styles.reset}
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === stylized);
+    assert(stripAnsi(out) === text);
+  });
+
+  test('ok + SKIP → orange', () => {
+    const text = dedent`
+      ok 1 - feature # SKIP nope
+    `;
+    const stylized = dedent`
+      ${styles.orange}ok 1 - feature # SKIP nope${styles.reset}
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === stylized);
+    assert(stripAnsi(out) === text);
+  });
+
+  test('not ok + TODO → orange (expected failure)', () => {
+    const text = dedent`
+      not ok 1 - pending # TODO later
+    `;
+    const stylized = dedent`
+      ${styles.orange}not ok 1 - pending # TODO later${styles.reset}
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === stylized);
+    assert(stripAnsi(out) === text);
+  });
+
+  test('ok + TODO → yellow (unexpectedly passing)', () => {
+    const text = dedent`
+      ok 1 - surprise # TODO meant to fail
+    `;
+    const stylized = dedent`
+      ${styles.yellow}ok 1 - surprise # TODO meant to fail${styles.reset}
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === stylized);
+    assert(stripAnsi(out) === text);
+  });
+
+  test('Bail out! → bold red', () => {
+    const text = dedent`
+      Bail out! launch timeout
+    `;
+    const stylized = dedent`
+      ${styles.boldRed}Bail out! launch timeout${styles.reset}
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === stylized);
+    assert(stripAnsi(out) === text);
+  });
+
+  test('# Subtest: → cyan', () => {
+    const text = '    # Subtest: render\n';
+    const stylized = `${styles.cyan}    # Subtest: render${styles.reset}\n`;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === stylized);
+    assert(stripAnsi(out) === text);
+  });
+
+  test('plan and version → dim', () => {
+    const text = dedent`
+      TAP version 14
+      1..3
+    `;
+    const stylized = dedent`
+      ${styles.dim}TAP version 14${styles.reset}
+      ${styles.dim}1..3${styles.reset}
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === stylized);
+    assert(stripAnsi(out) === text);
+  });
+
+  test('yaml body dimmed between fences', () => {
+    const text = dedent`
+          ---
+          message: boom
+          ...
+      ok 1 - after
+    `;
+    const stylized = dedent`
+      ${styles.dim}    ---${styles.reset}
+      ${styles.dim}    message: boom${styles.reset}
+      ${styles.dim}    ...${styles.reset}
+      ${styles.green}ok 1 - after${styles.reset}
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === stylized);
+    assert(stripAnsi(out) === text);
+  });
+
+  test('indented asserts keep indent, whole content colored', () => {
+    const text = '        ok 1 - deep\n';
+    const stylized = `${styles.green}        ok 1 - deep${styles.reset}\n`;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === stylized);
+    assert(stripAnsi(out) === text);
+  });
+});
+
+suite('failure re-iteration block', () => {
+  test('# Failures: enters the block; all subsequent `#` lines are red', () => {
+    const text = dedent`
+      # Failures:
+      #
+      # http://host/f.html
+      # > initialize
+      # Error: not ok
+      #     at XTestSuite.assert (http://host/x-test-suite.js:112:15)
+    `;
+    const stylized = dedent`
+      ${styles.red}# Failures:${styles.reset}
+      ${styles.red}#${styles.reset}
+      ${styles.red}# http://host/f.html${styles.reset}
+      ${styles.red}# > initialize${styles.reset}
+      ${styles.red}# Error: not ok${styles.reset}
+      ${styles.red}#     at XTestSuite.assert (http://host/x-test-suite.js:112:15)${styles.reset}
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === stylized);
+    assert(stripAnsi(out) === text);
+  });
+
+  test('URL and breadcrumb are red only AFTER # Failures:', () => {
+    const text = dedent`
+      # http://host/somewhere.html
+      # Failures:
+      # http://host/failed.html
+      # > leaf
+    `;
+    const stylized = dedent`
+      ${styles.dim}# http://host/somewhere.html${styles.reset}
+      ${styles.red}# Failures:${styles.reset}
+      ${styles.red}# http://host/failed.html${styles.reset}
+      ${styles.red}# > leaf${styles.reset}
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === stylized);
+    assert(stripAnsi(out) === text);
+  });
+
+  test('blank separator inside the block is red', () => {
+    const text = dedent`
+      # Failures:
+      # http://host/first.html
+      # > leaf
+      #
+      # http://host/second.html
+    `;
+    const stylized = dedent`
+      ${styles.red}# Failures:${styles.reset}
+      ${styles.red}# http://host/first.html${styles.reset}
+      ${styles.red}# > leaf${styles.reset}
+      ${styles.red}#${styles.reset}
+      ${styles.red}# http://host/second.html${styles.reset}
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === stylized);
+    assert(stripAnsi(out) === text);
+  });
+
+  test('truly empty line inside the block is red', () => {
+    const text = dedent`
+      # Failures:
+      # http://host/first.html
+
+      # http://host/second.html
+    `;
+    const stylized = dedent`
+      ${styles.red}# Failures:${styles.reset}
+      ${styles.red}# http://host/first.html${styles.reset}
+      ${styles.red}${styles.reset}
+      ${styles.red}# http://host/second.html${styles.reset}
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === stylized);
+    assert(stripAnsi(out) === text);
+  });
+
+  test('block is terminal — everything after # Failures: reads as failure commentary', () => {
+    const text = dedent`
+      # Failures:
+      # http://host/f.html
+      # > leaf
+      ok 1 - a stray test line
+      # ordinary comment
+    `;
+    // Once entered, the block swallows subsequent lines — including
+    //  things that look like test asserts — as failure commentary (red).
+    //  x-test never emits test lines after `# Failures:`; this test
+    //  locks in the defensive behavior if anything ever does.
+    const stylized = dedent`
+      ${styles.red}# Failures:${styles.reset}
+      ${styles.red}# http://host/f.html${styles.reset}
+      ${styles.red}# > leaf${styles.reset}
+      ${styles.red}ok 1 - a stray test line${styles.reset}
+      ${styles.red}# ordinary comment${styles.reset}
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === stylized);
+    assert(stripAnsi(out) === text);
+  });
+
+  test('summary `#` lines BEFORE the block stay dim', () => {
+    const text = dedent`
+      # tests 101
+      # pass 91
+      # fail 1
+      # Failures:
+    `;
+    const stylized = dedent`
+      ${styles.dim}# tests 101${styles.reset}
+      ${styles.dim}# pass 91${styles.reset}
+      ${styles.dim}# fail 1${styles.reset}
+      ${styles.red}# Failures:${styles.reset}
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    tap.write(text);
+    tap.end();
+    const out = stream.read().toString();
+    assert(out === stylized);
+    assert(stripAnsi(out) === text);
+  });
+});
+
+suite('edge cases', () => {
+  test('comments and non-TAP noise flow through', () => {
+    const text = dedent`
+      # a comment
+      random console.log output
+      ok 1 - real test
+    `;
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write(text);
+    tap.end();
+    assert.deepEqual(tap.result, {
+      ok: true,
+      pass: 1,
+      fail: 0,
+      skip: 0,
+      todo: 0,
+      count: 1,
+      plan: null,
+      bailed: false,
+      bailReason: null,
+    });
+  });
+
+  test('handles \\r\\n (Windows) line endings', () => {
+    const text = '1..1\r\nok 1 - hi\r\n';
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write(text);
+    tap.end();
+    assert.deepEqual(tap.result, {
+      ok: true,
+      pass: 1,
+      fail: 0,
+      skip: 0,
+      todo: 0,
+      count: 1,
+      plan: { start: 1, end: 1 },
+      bailed: false,
+      bailReason: null,
+    });
+  });
+
+  test('case-sensitive: OK / NOT OK are not asserts', () => {
+    const text = dedent`
+      OK 1
+      NOT OK 1
+    `;
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write(text);
+    tap.end();
+    assert.deepEqual(tap.result, {
+      ok: true,
+      pass: 0,
+      fail: 0,
+      skip: 0,
+      todo: 0,
+      count: 0,
+      plan: null,
+      bailed: false,
+      bailReason: null,
+    });
+  });
+
+  test('word boundary: "okay" is not an assert', () => {
+    const text = dedent`
+      okay then
+    `;
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write(text);
+    tap.end();
+    assert.deepEqual(tap.result, {
+      ok: true,
+      pass: 0,
+      fail: 0,
+      skip: 0,
+      todo: 0,
+      count: 0,
+      plan: null,
+      bailed: false,
+      bailReason: null,
+    });
+  });
+});
+
+suite('write() handles multi-line blobs (browser-bridge path)', () => {
+  test('YAML-bearing blob emitted as one console.log does not crash', () => {
+    const blob = dedent`
+      not ok 1 - something failed
+        ---
+        message: not ok
+        stack: |-
+          Error: not ok
+              at http://127.0.0.1:8080/x.js:1:1
+        ...
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: true });
+    assert.doesNotThrow(() => tap.write(blob));
+    assert(stream.read().toString().length > 0);
+    tap.end();
+    assert(tap.result.fail === 1);
+  });
+
+  test('blob output matches line-at-a-time output (color off)', () => {
+    const text = dedent`
+      TAP version 14
+      ok 1 - a
+        ---
+        body
+        ...
+      1..1
+    `;
+
+    const streamA = new PassThrough();
+    const tapA = new XTestCliTap({ stream: streamA, color: false });
+    tapA.write(text);
+    tapA.end();
+
+    const streamB = new PassThrough();
+    const tapB = new XTestCliTap({ stream: streamB, color: false });
+    for (const line of text.split('\n')) {
+      tapB.write(line);
+    }
+    tapB.end();
+
+    assert(streamA.read().toString() === streamB.read().toString());
+  });
+});
+
+suite('lifecycle guards', () => {
+  test('.result before end() throws', () => {
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    assert.throws(() => tap.result, /result accessed before end/);
+  });
+
+  test('.result after end() returns the frozen result', () => {
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.write('1..0');
+    tap.end();
+    assert.doesNotThrow(() => tap.result);
+    // Repeated reads return the same object.
+    assert(tap.result === tap.result);
+  });
+
+  test('write() after end() throws', () => {
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.end();
+    assert.throws(() => tap.write('ok 1 - late'), /write\(\) called after end/);
+  });
+
+  test('end() called twice throws', () => {
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    tap.end();
+    assert.throws(() => tap.end(), /end\(\) called more than once/);
+  });
+});

--- a/x-test-cli-browser.js
+++ b/x-test-cli-browser.js
@@ -1,91 +1,57 @@
-import { Parser } from 'tap-parser';
-
+/**
+ * Puppeteer driver. `run(options)` launches Chromium via puppeteer,
+ * handshakes with x-test, forwards each browser console event through
+ * `onConsole(text)`, and closes.
+ */
 export class XTestCliBrowserPuppeteer {
-  /**
-   * Run tests with optional coverage collection.
-   * @param {Object} options - Configuration options
-   * @param {string} options.url - Test page URL
-   * @param {boolean} options.coverage - Whether to collect coverage
-   * @param {Object} options.launchOptions - Puppeteer launch options
-   */
-  static async run(options) {
-    let url = options?.url ?? null;
-    const coverage = options?.coverage ?? false;
-    const launchOptions = options?.launchOptions ?? {};
-
-    let puppeteer;
-    try {
-      puppeteer = (await import('puppeteer')).default;
-    } catch {
-      const message = 'Error: "puppeteer" is not installed. Install it to use "--client=puppeteer".';
-      console.error(new Error(message)); // eslint-disable-line no-console
-      process.exit(1);
-    }
-
+  static async run({ url, coverage, launchOptions, launchTimeout, onConsole }) {
     if (coverage) {
       const urlObj = new URL(url);
       urlObj.searchParams.set('x-test-run-coverage', '');
       url = urlObj.href;
     }
 
+    let puppeteer;
     try {
-      // Launch browser
-      const browser = await puppeteer.launch({
-        timeout: 10_000,
-        args: ['--no-sandbox', '--disable-setuid-sandbox'],
-        ...launchOptions,
-      });
-
-      const page = await browser.newPage();
-
-      // Start coverage collection if supported and requested
-      if (coverage && page.coverage) {
-        await page.coverage.startJSCoverage();
-      }
-
-      // Set up TAP parser for validation
-      const parser = new Parser(results => {
-        if (!results.ok) {
-          process.exit(1);
-        }
-      });
-
-      // Capture console output and parse as TAP
-      page.on('console', message => {
-        const text = message.text();
-        console.log(text); // eslint-disable-line no-console
-        parser.write(text + '\n');
-      });
-
-      // Navigate to test page
-      await page.goto(url);
-
-      // Wait for test readiness. The browser tells us whether it’s asking
-      //  for coverage data — only call `cover()` when it is, otherwise we
-      //  hang forever waiting for a second `x-test-root-end` that never comes.
-      const { coverageRequested } = await page.evaluate(XTestCliBrowserPuppeteer.#runScript());
-
-      // Handle coverage if the browser requested it.
-      if (coverage && page.coverage && coverageRequested) {
-        const js = await page.coverage.stopJSCoverage();
-        await page.evaluate(XTestCliBrowserPuppeteer.#coverScript(), { js });
-      }
-
-      // Close parser
-      parser.end();
-
-      // Close browser
-      await browser.close();
-    } catch (error) {
-      XTestCliBrowserPuppeteer.#bail(error);
+      puppeteer = (await import('puppeteer')).default;
+    } catch {
+      throw new Error('"puppeteer" is not installed. Install it to use "--client=puppeteer".');
     }
+
+    const browser = await puppeteer.launch({
+      timeout: launchTimeout,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      ...launchOptions,
+    });
+    const page = await browser.newPage();
+
+    if (coverage) {
+      if (!page.coverage) {
+        throw new Error('Coverage was requested but `page.coverage` is unavailable in this browser.');
+      }
+      await page.coverage.startJSCoverage();
+    }
+
+    page.on('console', message => {
+      onConsole(message.text());
+    });
+
+    await page.goto(url);
+
+    const { coverageRequested } = await page.evaluate(XTestCliBrowserPuppeteer.#runScript());
+
+    if (coverage && coverageRequested) {
+      // Puppeteer already emits `{text, ranges}` — no normalization needed.
+      const js = await page.coverage.stopJSCoverage();
+      await page.evaluate(XTestCliBrowserPuppeteer.#coverScript(), { js });
+    }
+
+    await browser.close();
   }
 
   /**
    * Browser-injected factory: handshakes with x-test over BroadcastChannel
-   * and resolves with `{ coverageRequested, ended }` — telling the caller
-   * which terminal event fired, so coverage can be skipped when the root
-   * didn’t ask for it.
+   * and resolves once the run has ended (or coverage has been requested).
    */
   static #runScript() {
     return async () => {
@@ -140,111 +106,69 @@ export class XTestCliBrowserPuppeteer {
       });
     };
   }
-
-  /**
-   * Emit TAP `Bail out!` and exit non-zero on a catastrophic driver failure
-   * (browser launch, navigation, etc. — anything thrown before or during run).
-   */
-  static #bail(error) {
-    console.log('Bail out!'); // eslint-disable-line no-console
-    console.error(error); // eslint-disable-line no-console
-    process.exit(1);
-  }
 }
 
+/**
+ * Playwright driver. `run(options)` launches Chromium via playwright,
+ * handshakes with x-test, forwards each browser console event through
+ * `onConsole(text)`, normalizes V8 coverage to Puppeteer's shape, and closes.
+ */
 export class XTestCliBrowserPlaywright {
-  /**
-   * Run tests with optional coverage collection.
-   * @param {Object} options - Configuration options
-   * @param {string} options.url - Test page URL
-   * @param {boolean} options.coverage - Whether to collect coverage
-   * @param {Object} options.launchOptions - Playwright launch options
-   */
-  static async run(options) {
-    let url = options?.url ?? null;
-    const coverage = options?.coverage ?? false;
-    const launchOptions = options?.launchOptions ?? {};
-
-    let playwright;
-    try {
-      playwright = await import('playwright');
-    } catch {
-      const message = 'Error: "playwright" is not installed. Install it to use "--client=playwright".';
-      console.error(new Error(message)); // eslint-disable-line no-console
-      process.exit(1);
-    }
-
+  static async run({ url, coverage, launchOptions, launchTimeout, onConsole }) {
     if (coverage) {
       const urlObj = new URL(url);
       urlObj.searchParams.set('x-test-run-coverage', '');
       url = urlObj.href;
     }
 
+    let playwright;
     try {
-      // Launch browser
-      const browser = await playwright.chromium.launch({
-        timeout: 10_000,
-        args: ['--no-sandbox', '--disable-setuid-sandbox'],
-        ...launchOptions,
-      });
-
-      const page = await browser.newPage();
-
-      // Start coverage collection if supported and requested
-      if (coverage && page.coverage) {
-        await page.coverage.startJSCoverage();
-      }
-
-      // Set up TAP parser for validation
-      const parser = new Parser(results => {
-        if (!results.ok) {
-          process.exit(1);
-        }
-      });
-
-      // Capture console output and parse as TAP
-      page.on('console', message => {
-        const text = message.text();
-        console.log(text); // eslint-disable-line no-console
-        parser.write(text + '\n');
-      });
-
-      // Navigate to test page
-      await page.goto(url);
-
-      // Wait for test readiness. The browser tells us whether it’s asking
-      //  for coverage data — only call `cover()` when it is, otherwise we
-      //  hang forever waiting for a second `x-test-root-end` that never comes.
-      const { coverageRequested } = await page.evaluate(XTestCliBrowserPlaywright.#runScript());
-
-      // Handle coverage if the browser requested it. Playwright’s raw V8
-      //  shape needs to be normalized to match what Puppeteer emits so the
-      //  downstream x-test code sees identical input regardless of client.
-      if (coverage && page.coverage && coverageRequested) {
-        const raw = await page.coverage.stopJSCoverage();
-        const js = XTestCliBrowserPlaywright.#normalizeCoverage(raw);
-        await page.evaluate(XTestCliBrowserPlaywright.#coverScript(), { js });
-      }
-
-      // Close parser
-      parser.end();
-
-      // Close browser
-      await browser.close();
-    } catch (error) {
-      XTestCliBrowserPlaywright.#bail(error);
+      playwright = await import('playwright');
+    } catch {
+      throw new Error('"playwright" is not installed. Install it to use "--client=playwright".');
     }
+
+    const browser = await playwright.chromium.launch({
+      timeout: launchTimeout,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      ...launchOptions,
+    });
+    const page = await browser.newPage();
+
+    if (coverage) {
+      if (!page.coverage) {
+        throw new Error('Coverage was requested but `page.coverage` is unavailable in this browser.');
+      }
+      await page.coverage.startJSCoverage();
+    }
+
+    page.on('console', message => {
+      onConsole(message.text());
+    });
+
+    await page.goto(url);
+
+    const { coverageRequested } = await page.evaluate(XTestCliBrowserPlaywright.#runScript());
+
+    if (coverage && coverageRequested) {
+      const raw = await page.coverage.stopJSCoverage();
+      const js = XTestCliBrowserPlaywright.normalizeCoverage(raw);
+      await page.evaluate(XTestCliBrowserPlaywright.#coverScript(), { js });
+    }
+
+    await browser.close();
   }
 
   /**
-   * Reshape Playwright’s raw V8 coverage (`{source, functions}`) into
-   * Puppeteer’s simplified `{text, ranges}` form.
+   * Reshape Playwright's raw V8 coverage (`{source, functions}`) into
+   * Puppeteer's `{text, ranges}` form so downstream x-test processing
+   * sees identical input regardless of client.
    *
-   * NOTE: first-pass normalization — flattens ranges with count > 0 without
-   * merging overlapping ranges or subtracting nested uncovered blocks.
-   * Follow-up will port Puppeteer’s `convertToDisjointRanges`.
+   * NOTE: first-pass normalization — flattens ranges with count > 0
+   * without merging overlapping ranges or subtracting nested uncovered
+   * blocks. Follow-up will port Puppeteer's `convertToDisjointRanges`.
    */
-  static #normalizeCoverage(entries) {
+  static normalizeCoverage(entries) {
     return entries.map(({ url, scriptId, source, functions }) => {
       const ranges = [];
       for (const fn of functions ?? []) {
@@ -260,9 +184,7 @@ export class XTestCliBrowserPlaywright {
 
   /**
    * Browser-injected factory: handshakes with x-test over BroadcastChannel
-   * and resolves with `{ coverageRequested, ended }` — telling the caller
-   * which terminal event fired, so coverage can be skipped when the root
-   * didn’t ask for it.
+   * and resolves once the run has ended (or coverage has been requested).
    */
   static #runScript() {
     return async () => {
@@ -316,15 +238,5 @@ export class XTestCliBrowserPlaywright {
         channel.postMessage({ type: 'x-test-client-coverage-result', data });
       });
     };
-  }
-
-  /**
-   * Emit TAP `Bail out!` and exit non-zero on a catastrophic driver failure
-   * (browser launch, navigation, etc. — anything thrown before or during run).
-   */
-  static #bail(error) {
-    console.log('Bail out!'); // eslint-disable-line no-console
-    console.error(error); // eslint-disable-line no-console
-    process.exit(1);
   }
 }

--- a/x-test-cli-tap.js
+++ b/x-test-cli-tap.js
@@ -1,0 +1,285 @@
+/**
+ * Single authority for TAP interpretation, result accumulation, and rendering.
+ */
+export class XTestCliTap {
+  // Whole-line TAP patterns, iterated in declaration order.
+  static #patterns = {
+    yamlOpen:       /^\s*---\s*$/,
+    bail:           /^\s*Bail out!(?:\s+(?<reason>.*?))?\s*$/,
+    subtest:        /^\s*# Subtest:.*$/,
+    failuresHeader: /^\s*# Failures:\s*$/,
+    version:        /^\s*TAP [Vv]ersion\b.*$/,
+    plan:           /^\s*(?<start>\d+)\.\.(?<end>\d+)(?:\s+#.*)?$/,
+    testSkip:       /^\s*ok\b.*#\s*SKIP\b.*$/,
+    testTodoOk:     /^\s*ok\b.*#\s*TODO\b.*$/,
+    testTodoNotOk:  /^\s*not ok\b.*#\s*TODO\b.*$/,
+    testOk:         /^\s*ok\b.*$/,
+    testNotOk:      /^\s*not ok\b.*$/,
+    comment:        /^\s*#.*$/,
+    blank:          /^\s*$/,
+    unknown:        /^/,
+  };
+
+  // YAML-specific, whole-line TAP patterns, iterated in declaration order.
+  static #inYamlPatterns = {
+    yamlClose:   /^\s*\.\.\.\s*$/,
+    yamlUnknown: new RegExp(XTestCliTap.#patterns.unknown.source),
+  };
+
+  // Failure-specific, whole-line TAP patterns, iterated in declaration order.
+  static #inFailurePatterns = {
+    failureComment: new RegExp(XTestCliTap.#patterns.comment.source),
+    failureBlank:   new RegExp(XTestCliTap.#patterns.blank.source),
+    failureUnknown: new RegExp(XTestCliTap.#patterns.unknown.source),
+  };
+
+  // Named ANSI styles to colorize / stylize stdout text.
+  static #styles = {
+    reset:   '\x1b[0m',
+    dim:     '\x1b[2m',
+    boldRed: '\x1b[1;31m',
+    red:     '\x1b[31m',
+    green:   '\x1b[32m',
+    yellow:  '\x1b[33m',
+    orange:  '\x1b[38;5;208m',
+    cyan:    '\x1b[36m',
+  };
+
+  #stream;
+  #color;
+  #state = {
+    inYaml:         false, // classification mode flag — inside a `---`/`...` block
+    inFailureBlock: false, // classification mode flag — inside `# Failures:` trailer
+    ended:          false, // set by end(); gates write/end/result
+    result:         null,  // frozen snapshot produced by end()
+    plan:           null,  // captured at the 1..N line, checked at end
+    pass:           0,     // passing asserts
+    fail:           0,     // failing asserts (drives exit code)
+    skip:           0,     // `# SKIP`-directive asserts
+    todo:           0,     // `# TODO`-directive not-ok asserts (expected failures)
+    count:          0,     // total asserts seen, validated against plan
+    bailed:         false, // set on encountering a Bail out! line
+    bailReason:     null,  // free text after `Bail out!`, if any
+  };
+
+  constructor({ stream, color }) {
+    this.#stream = stream;
+    this.#color = color;
+  }
+
+  /**
+   * Feed a blob of TAP text. May contain embedded `\n` or `\r\n` — the browser
+   * delivers multi-line YAML diagnostics as a single console.log call.
+   * Splitting on `\r?\n` absorbs Windows line endings as part of the delimiter
+   * so downstream classification sees clean lines with no trailing `\r`.
+   */
+  write(blob) {
+    if (this.#state.ended) {
+      throw new Error('XTestCliTap: write() called after end().');
+    }
+    // A trailing `\n` terminates the final line — don't treat it as a
+    //  separator that opens a phantom empty line after it.
+    const lines = blob.split(/\r?\n/);
+    if (lines.length > 0 && lines[lines.length - 1] === '') {
+      lines.pop();
+    }
+    for (const line of lines) {
+      this.#processLine(line);
+    }
+  }
+
+  /**
+   * Finalize. The aggregated result is thereafter available on `.result`.
+   */
+  end() {
+    if (this.#state.ended) {
+      throw new Error('XTestCliTap: end() called more than once.');
+    }
+    let ok = true;
+    if (this.#state.bailed) {
+      ok = false;
+    }
+    if (this.#state.fail > 0) {
+      ok = false;
+    }
+    if (this.#state.plan) {
+      const planned = this.#state.plan.end - this.#state.plan.start + 1;
+      if (planned !== this.#state.count) {
+        ok = false;
+      }
+    }
+    this.#state.result = {
+      ok,
+      pass: this.#state.pass,
+      fail: this.#state.fail,
+      skip: this.#state.skip,
+      todo: this.#state.todo,
+      count: this.#state.count,
+      plan: this.#state.plan,
+      bailed: this.#state.bailed,
+      bailReason: this.#state.bailReason,
+    };
+    this.#state.ended = true;
+  }
+
+  /**
+   * Aggregated result, available only after `end()` has been called.
+   */
+  get result() {
+    if (!this.#state.ended) {
+      throw new Error('XTestCliTap: result accessed before end().');
+    }
+    return this.#state.result;
+  }
+
+  /**
+   * The single rendering path for every switch case. `style` is an ANSI opening
+   * escape from `#styles` — omit it to pass the line through raw.
+   */
+  #emit(line, style) {
+    const text = style && this.#color
+      ? `${style}${line}${XTestCliTap.#styles.reset}`
+      : line;
+    this.#stream.write(text + '\n');
+  }
+
+  /**
+   * Find the pattern that classifies `line`. State picks which set to
+   * iterate; each set ends in a catch-all sentinel (`unknown`, `yamlUnknown`,
+   * `failureUnknown`) so a hit is guaranteed.
+   */
+  #tryPatterns(line) {
+    const patterns = this.#state.inYaml
+      ? XTestCliTap.#inYamlPatterns
+      : this.#state.inFailureBlock
+        ? XTestCliTap.#inFailurePatterns
+        : XTestCliTap.#patterns;
+    for (const pattern of Object.values(patterns)) {
+      const match = pattern.exec(line);
+      if (match) {
+        return { pattern, match };
+      }
+    }
+    throw new Error('Invariant violated: every pattern set must end in a catch-all sentinel.');
+  }
+
+  /**
+   * Classify one line, mutate state (counters, sticky flags, plan, bail), and
+   * emit it through `#emit` with the style that matches its classification.
+   * Every path through the switch sets `style` (or leaves it undefined for raw
+   * passthrough), so the single call to `#emit` at the end renders uniformly.
+   */
+  #processLine(line) {
+    const { pattern, match } = this.#tryPatterns(line);
+
+    // Only top-level plans and asserts feed our counters / plan state. Indented
+    //  lines come from nested sub-tests, which producers self-validate and roll
+    //  up to a parent assert — so the top-level count + plan is the right
+    //  signal for exit code. We render nested lines (colorize) but don’t factor
+    //  them into `count`. If we ever want per-subtest stats, we’d need a scope
+    //  stack. For a CLI exit-code, the top-level rollup is enough.
+    const atTopLevel = !/^\s/.test(line);
+
+    let style;
+    switch (pattern) {
+      case XTestCliTap.#patterns.yamlOpen:
+        this.#state.inYaml = true;
+        style = XTestCliTap.#styles.dim;
+        break;
+      case XTestCliTap.#inYamlPatterns.yamlClose:
+        this.#state.inYaml = false;
+        style = XTestCliTap.#styles.dim;
+        break;
+      case XTestCliTap.#inYamlPatterns.yamlUnknown:
+        // In-yaml body — dim the whole line regardless of its content.
+        style = XTestCliTap.#styles.dim;
+        break;
+      case XTestCliTap.#patterns.bail:
+        this.#state.bailed = true;
+        this.#state.bailReason = match.groups.reason ?? null;
+        style = XTestCliTap.#styles.boldRed;
+        break;
+      case XTestCliTap.#patterns.subtest:
+        style = XTestCliTap.#styles.cyan;
+        break;
+      case XTestCliTap.#patterns.failuresHeader:
+        // Sticky: once the trailing failure re-iteration block starts,
+        //  subsequent comments/blanks stay red until an assert fires.
+        this.#state.inFailureBlock = true;
+        style = XTestCliTap.#styles.red;
+        break;
+      case XTestCliTap.#patterns.version:
+        style = XTestCliTap.#styles.dim;
+        break;
+      case XTestCliTap.#patterns.plan:
+        if (atTopLevel) {
+          const start = Number(match.groups.start);
+          const end = Number(match.groups.end);
+          this.#state.plan = { start, end };
+        }
+        style = XTestCliTap.#styles.dim;
+        break;
+      case XTestCliTap.#patterns.testSkip:
+        this.#state.inFailureBlock = false;
+        if (atTopLevel) {
+          this.#state.count++;
+          this.#state.skip++;
+        }
+        style = XTestCliTap.#styles.orange;
+        break;
+      case XTestCliTap.#patterns.testTodoOk:
+        this.#state.inFailureBlock = false;
+        if (atTopLevel) {
+          this.#state.count++;
+          this.#state.pass++;
+        }
+        style = XTestCliTap.#styles.yellow; // TODO that passed! Style yellow.
+        break;
+      case XTestCliTap.#patterns.testTodoNotOk:
+        this.#state.inFailureBlock = false;
+        if (atTopLevel) {
+          this.#state.count++;
+          this.#state.todo++;
+        }
+        style = XTestCliTap.#styles.orange;
+        break;
+      case XTestCliTap.#patterns.testOk:
+        this.#state.inFailureBlock = false;
+        if (atTopLevel) {
+          this.#state.count++;
+          this.#state.pass++;
+        }
+        style = XTestCliTap.#styles.green;
+        break;
+      case XTestCliTap.#patterns.testNotOk:
+        this.#state.inFailureBlock = false;
+        if (atTopLevel) {
+          this.#state.count++;
+          this.#state.fail++;
+        }
+        style = XTestCliTap.#styles.red;
+        break;
+      case XTestCliTap.#patterns.comment:
+        style = XTestCliTap.#styles.dim;
+        break;
+      case XTestCliTap.#inFailurePatterns.failureComment:
+        style = XTestCliTap.#styles.red;
+        break;
+      case XTestCliTap.#patterns.blank:
+        // Raw — leave `style` undefined.
+        break;
+      case XTestCliTap.#inFailurePatterns.failureBlank:
+        style = XTestCliTap.#styles.red;
+        break;
+      case XTestCliTap.#inFailurePatterns.failureUnknown:
+        // Catch-all inside the failure block — everything reads as
+        //  failure commentary regardless of shape.
+        style = XTestCliTap.#styles.red;
+        break;
+      case XTestCliTap.#patterns.unknown:
+        // Non-TAP noise — leave `style` undefined to pass through raw.
+        break;
+    }
+    this.#emit(line, style);
+  }
+}

--- a/x-test-cli.js
+++ b/x-test-cli.js
@@ -1,12 +1,18 @@
 #!/usr/bin/env node
 
 import { XTestCliBrowserPuppeteer, XTestCliBrowserPlaywright } from './x-test-cli-browser.js';
+import { XTestCliTap } from './x-test-cli-tap.js';
 
 const SUPPORTED_CLIENTS = ['puppeteer', 'playwright'];
+const SUPPORTED_REPORTERS = ['tap', 'auto'];
 
-// Define allowed arguments
-const ALLOWED_ARGS = ['client', 'url',  'coverage', 'test-name'];
+const ALLOWED_ARGS = ['client', 'url', 'coverage', 'test-name', 'reporter'];
 const ALLOWED_ARGS_DEBUG = ALLOWED_ARGS.map(arg => `"--${arg}"`).join(', ');
+
+function fail(message) {
+  console.error(message); // eslint-disable-line no-console
+  process.exit(1);
+}
 
 // Parse command line arguments
 const args = process.argv.slice(2);
@@ -16,91 +22,103 @@ for (const arg of args) {
   if (arg.startsWith('--')) {
     const [key, value] = arg.slice(2).split('=', 2);
 
-    // Check if argument is allowed
     if (!ALLOWED_ARGS.includes(key)) {
-      const primaryMessage = `Error: Unknown argument "--${key}".`;
-      const secondaryMessage = `Allowed arguments: ${ALLOWED_ARGS_DEBUG}.`;
-      const message = [primaryMessage, secondaryMessage].join('\n');
-      console.error(new Error(message)); // eslint-disable-line no-console
-      process.exit(1);
+      fail(`Error: Unknown argument "--${key}".\nAllowed arguments: ${ALLOWED_ARGS_DEBUG}.`);
     }
 
-    // Check if value is provided
     if (value === undefined) {
-      const message = `Error: Argument "--${key}" requires a value (e.g., "--${key}=<value>").`;
-      console.error(new Error(message)); // eslint-disable-line no-console
-      process.exit(1);
+      fail(`Error: Argument "--${key}" requires a value (e.g., "--${key}=<value>").`);
     }
 
-    // Map kebab-case to camelCase for internal use
-    const camelKey = key === 'test-name' ? 'testName' : key;
+    // kebab-case flag → camelCase internal key, e.g. `test-name` → `testName`.
+    const camelKey = key.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
     options[camelKey] = value;
   } else {
-    const message = `Error: Invalid argument "${arg}". All arguments must start with "--".`;
-    console.error(new Error(message)); // eslint-disable-line no-console
-    process.exit(1);
+    fail(`Error: Invalid argument "${arg}". All arguments must start with "--".`);
   }
 }
 
-// Validate required arguments
 if (!options.client) {
-  const message = 'Error: "--client" is required (e.g., "--client=puppeteer").';
-  console.error(new Error(message)); // eslint-disable-line no-console
-  process.exit(1);
+  fail('Error: "--client" is required (e.g., "--client=puppeteer").');
 }
 
 if (!options.url) {
-  const message = 'Error: "--url" is required (e.g., "--url=http://localhost:8080/test/").';
-  console.error(new Error(message)); // eslint-disable-line no-console
-  process.exit(1);
+  fail('Error: "--url" is required (e.g., "--url=http://localhost:8080/test/").');
 }
 
-// Validate client type
 if (!SUPPORTED_CLIENTS.includes(options.client)) {
   const supported = SUPPORTED_CLIENTS.map(client => `"${client}"`).join(', ');
-  const message = `Error: Unsupported client "${options.client}". Supported clients: ${supported}.`;
-  console.error(new Error(message)); // eslint-disable-line no-console
+  fail(`Error: Unsupported client "${options.client}". Supported clients: ${supported}.`);
+}
+
+// Convert coverage string to boolean. Default is false; `--coverage=true`
+//  enables, `--coverage=false` is an explicit no-op (kept for symmetry).
+let coverage = false;
+if (options.coverage === 'true') {
+  coverage = true;
+} else if (options.coverage !== undefined && options.coverage !== 'false') {
+  fail(`Error: --coverage must be "true" or "false", got "${options.coverage}".`);
+}
+
+const reporterMode = options.reporter ?? 'auto';
+if (!SUPPORTED_REPORTERS.includes(reporterMode)) {
+  const supported = SUPPORTED_REPORTERS.map(reporter => `"${reporter}"`).join(', ');
+  fail(`Error: Unsupported reporter "${reporterMode}". Supported reporters: ${supported}.`);
+}
+
+// Resolve whether to colorize. Precedence (highest first):
+//   1. `--reporter=tap` forces raw (explicit user intent on this run)
+//   2. `NO_COLOR` env var (https://no-color.org)
+//   3. `FORCE_COLOR` env var (ecosystem de facto)
+//   4. TTY detection on stdout
+const suppressColor = reporterMode === 'tap' || process.env.NO_COLOR;
+const forceColor    = process.env.FORCE_COLOR || process.stdout.isTTY;
+const color         = !suppressColor && !!forceColor;
+
+// Own the TAP reporter here — the driver just emits browser console lines. This
+//  entry point decides what to do with them.
+const tap = new XTestCliTap({ stream: process.stdout, color });
+
+// Resolve the target URL (apply the test-name filter if present).
+let url = options.url;
+if (options.testName) {
+  const urlObj = new URL(url);
+  urlObj.searchParams.set('x-test-name', options.testName);
+  url = urlObj.href;
+}
+
+// Browser-launch timeout (ms). Applies only to the underlying puppeteer or
+//  playwright `launch()` call — “fail fast if the browser can’t start.” Not a
+//  run timeout.
+const LAUNCH_TIMEOUT_MS = 10_000;
+
+const driverOptions = {
+  url,
+  coverage,
+  launchTimeout: LAUNCH_TIMEOUT_MS,
+  onConsole: text => tap.write(text),
+};
+
+// Run the browser driver. On any catastrophic failure (browser launch,
+//  navigation, etc.) emit `Bail out!` through the reporter so it gets colorized
+//  and the scanner records the bailed state, then dump the error to stderr
+//  (outside the TAP stream) and exit 1.
+try {
+  switch (options.client) {
+    case 'puppeteer':
+      await XTestCliBrowserPuppeteer.run(driverOptions);
+      break;
+    case 'playwright':
+      await XTestCliBrowserPlaywright.run(driverOptions);
+      break;
+  }
+} catch (error) {
+  tap.write(`Bail out! The ${options.client} client crashed.`);
+  console.error(error); // eslint-disable-line no-console
   process.exit(1);
 }
 
-// Convert coverage string to boolean
-let coverage = false;
-if (options.coverage) {
-  if (options.coverage === 'true') {
-    coverage = true;
-  } else if (options.coverage === 'false') {
-    coverage = false;
-  } else {
-    const message = `Error: --coverage must be "true" or "false", got "${options.coverage}".`;
-    console.error(new Error(message)); // eslint-disable-line no-console
-    process.exit(1);
-  }
-}
-
-// Build client options
-const clientOptions = {
-  url: options.url,
-  coverage,
-};
-
-// Handle testName filtering by adding to URL
-if (options.testName) {
-  const urlObj = new URL(clientOptions.url);
-  urlObj.searchParams.set('x-test-name', options.testName);
-  clientOptions.url = urlObj.href;
-}
-
-// Run the appropriate client
-switch (options.client) {
-  case 'puppeteer':
-    await XTestCliBrowserPuppeteer.run(clientOptions);
-    break;
-  case 'playwright':
-    await XTestCliBrowserPlaywright.run(clientOptions);
-    break;
-  default: {
-    const message = `Error: Unsupported client "${options.client}".`;
-    console.error(new Error(message)); // eslint-disable-line no-console
-    process.exit(1);
-  }
+tap.end();
+if (!tap.result.ok) {
+  process.exit(1);
 }


### PR DESCRIPTION
This is a minimal CLI for a minimal testing library. We can be very targeted about the problems we seek to solve. As such, a _very_ small subset of TAP-parsing functionality is needed — more than would warrant pulling in `tap-parser` at this point. We add `x-test-cli-tap.js` to handle all our TAP-y needs.

To keep things interoperable with the previous pass-through output, we allow developers to pass `--reporter=tap` (mimicking Node’s naming). Otherwise, developers now get a stylized output in their terminal. Care was taken to handle cases where developers have indicated (or implied) that they do not _want_ stylized output (e.g., while piping to something like `grep`).

Finally, the TAP output _text_ content is not changed, just stylized. I.e., stripping back out the stylization would leave you with the original text from x-test.

Closes #4 and closes #7.