### PR TITLE
Fail faster for common server errors (e.g. 404).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `--timeout=<ms>` flag bounding the full run launch, navigate, handshake, and
+  coverage — defaults to 30s (#14).
+- Fail-fast on obviously-wrong URLs: the CLI now bails immediately when the
+  initial navigation returns a `>= 400` HTTP status (#14).
 - NPM token lives in a GH environment for publish action (more secure).
 
 ## [1.0.0-rc.3] - 2026-04-21

--- a/x-test-cli-browser.js
+++ b/x-test-cli-browser.js
@@ -23,30 +23,39 @@ export class XTestCliBrowserPuppeteer {
       args: ['--no-sandbox', '--disable-setuid-sandbox'],
       ...launchOptions,
     });
-    const page = await browser.newPage();
+    try {
+      const page = await browser.newPage();
 
-    if (coverage) {
-      if (!page.coverage) {
-        throw new Error('Coverage was requested but `page.coverage` is unavailable in this browser.');
+      if (coverage) {
+        if (!page.coverage) {
+          throw new Error('Coverage was requested but `page.coverage` is unavailable in this browser.');
+        }
+        await page.coverage.startJSCoverage();
       }
-      await page.coverage.startJSCoverage();
+
+      page.on('console', message => {
+        onConsole(message.text());
+      });
+
+      // Signal intent to content-negotiating servers so they can 4xx early
+      //  instead of serving a non-HTML variant. Static servers ignore this.
+      await page.setExtraHTTPHeaders({ Accept: 'text/html' });
+
+      const response = await page.goto(url);
+      if (response && response.status() >= 400) {
+        throw new Error(`Got HTTP ${response.status()} for ${url}. Is the url correct?`);
+      }
+
+      const { coverageRequested } = await page.evaluate(XTestCliBrowserPuppeteer.#runScript());
+
+      if (coverage && coverageRequested) {
+        // Puppeteer already emits `{text, ranges}` — no normalization needed.
+        const js = await page.coverage.stopJSCoverage();
+        await page.evaluate(XTestCliBrowserPuppeteer.#coverScript(), { js });
+      }
+    } finally {
+      await browser.close();
     }
-
-    page.on('console', message => {
-      onConsole(message.text());
-    });
-
-    await page.goto(url);
-
-    const { coverageRequested } = await page.evaluate(XTestCliBrowserPuppeteer.#runScript());
-
-    if (coverage && coverageRequested) {
-      // Puppeteer already emits `{text, ranges}` — no normalization needed.
-      const js = await page.coverage.stopJSCoverage();
-      await page.evaluate(XTestCliBrowserPuppeteer.#coverScript(), { js });
-    }
-
-    await browser.close();
   }
 
   /**
@@ -133,30 +142,39 @@ export class XTestCliBrowserPlaywright {
       args: ['--no-sandbox', '--disable-setuid-sandbox'],
       ...launchOptions,
     });
-    const page = await browser.newPage();
+    try {
+      const page = await browser.newPage();
 
-    if (coverage) {
-      if (!page.coverage) {
-        throw new Error('Coverage was requested but `page.coverage` is unavailable in this browser.');
+      if (coverage) {
+        if (!page.coverage) {
+          throw new Error('Coverage was requested but `page.coverage` is unavailable in this browser.');
+        }
+        await page.coverage.startJSCoverage();
       }
-      await page.coverage.startJSCoverage();
+
+      page.on('console', message => {
+        onConsole(message.text());
+      });
+
+      // Signal intent to content-negotiating servers so they can 4xx early
+      //  instead of serving a non-HTML variant. Static servers ignore this.
+      await page.setExtraHTTPHeaders({ Accept: 'text/html' });
+
+      const response = await page.goto(url);
+      if (response && response.status() >= 400) {
+        throw new Error(`Got HTTP ${response.status()} for ${url}. Is the url correct?`);
+      }
+
+      const { coverageRequested } = await page.evaluate(XTestCliBrowserPlaywright.#runScript());
+
+      if (coverage && coverageRequested) {
+        const raw = await page.coverage.stopJSCoverage();
+        const js = XTestCliBrowserPlaywright.normalizeCoverage(raw);
+        await page.evaluate(XTestCliBrowserPlaywright.#coverScript(), { js });
+      }
+    } finally {
+      await browser.close();
     }
-
-    page.on('console', message => {
-      onConsole(message.text());
-    });
-
-    await page.goto(url);
-
-    const { coverageRequested } = await page.evaluate(XTestCliBrowserPlaywright.#runScript());
-
-    if (coverage && coverageRequested) {
-      const raw = await page.coverage.stopJSCoverage();
-      const js = XTestCliBrowserPlaywright.normalizeCoverage(raw);
-      await page.evaluate(XTestCliBrowserPlaywright.#coverScript(), { js });
-    }
-
-    await browser.close();
   }
 
   /**

--- a/x-test-cli.js
+++ b/x-test-cli.js
@@ -6,7 +6,7 @@ import { XTestCliTap } from './x-test-cli-tap.js';
 const SUPPORTED_CLIENTS = ['puppeteer', 'playwright'];
 const SUPPORTED_REPORTERS = ['tap', 'auto'];
 
-const ALLOWED_ARGS = ['client', 'url', 'coverage', 'test-name', 'reporter'];
+const ALLOWED_ARGS = ['client', 'url', 'coverage', 'test-name', 'reporter', 'timeout'];
 const ALLOWED_ARGS_DEBUG = ALLOWED_ARGS.map(arg => `"--${arg}"`).join(', ');
 
 function fail(message) {
@@ -60,6 +60,17 @@ if (options.coverage === 'true') {
   fail(`Error: --coverage must be "true" or "false", got "${options.coverage}".`);
 }
 
+// Run timeout (ms). Bounds the handshake with the x-test root so a missing or
+//  broken root can’t hang the CLI forever. Default 30s.
+let runTimeout = 30_000;
+if (options.timeout !== undefined) {
+  const parsed = Number(options.timeout);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    fail(`Error: --timeout must be a positive number of milliseconds, got "${options.timeout}".`);
+  }
+  runTimeout = parsed;
+}
+
 const reporterMode = options.reporter ?? 'auto';
 if (!SUPPORTED_REPORTERS.includes(reporterMode)) {
   const supported = SUPPORTED_REPORTERS.map(reporter => `"${reporter}"`).join(', ');
@@ -99,17 +110,30 @@ const driverOptions = {
   onConsole: text => tap.write(text),
 };
 
+// Global run timeout. Races the driver against a timer — covers launch,
+//  navigation, handshake, and coverage uniformly. The losing promise keeps
+//  running, but we `process.exit(1)` below and the driver packages install
+//  exit handlers that tear down Chromium.
+function withTimeout(promise, ms, message) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
 // Run the browser driver. On any catastrophic failure (browser launch,
 //  navigation, etc.) emit `Bail out!` through the reporter so it gets colorized
 //  and the scanner records the bailed state, then dump the error to stderr
 //  (outside the TAP stream) and exit 1.
+const timeoutMessage = `Timed out after ${runTimeout}ms waiting for x-test root at ${url}. Use --timeout=<ms> to extend.`;
 try {
   switch (options.client) {
     case 'puppeteer':
-      await XTestCliBrowserPuppeteer.run(driverOptions);
+      await withTimeout(XTestCliBrowserPuppeteer.run(driverOptions), runTimeout, timeoutMessage);
       break;
     case 'playwright':
-      await XTestCliBrowserPlaywright.run(driverOptions);
+      await withTimeout(XTestCliBrowserPlaywright.run(driverOptions), runTimeout, timeoutMessage);
       break;
   }
 } catch (error) {


### PR DESCRIPTION
This change set covers some common cases:

- Server takes to long to respond for whatever reason - timeout / bail.
- Server responds with 4xx / 5xx error — bail.
- Server response with non HTML — bail.

Closes #14.