### PR TITLE
Finess interface a bit more.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Config key `coverageBasePath` renamed to `root`. Stricter validation: must
+  be a `./`- or `../`-prefixed string (#22).
+- Config key `coverageTargets` renamed to `coverageGoals`. Each key is now
+  also required to be `./`- or `../`-prefixed (#22).
+
+### Added
+
+- `--root=<path>` CLI flag. Mirrors the config key for ad-hoc overrides
+  (e.g. `--root=./build` to point at a vite-built dist without editing
+  config). Validated unconditionally (#22).
+
 ## [1.0.0-rc.5] - 2026-04-23
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,5 +62,5 @@ The bump script automatically updates `package.json`, `package-lock.json`, and `
 - ES modules (`"type": "module"` in package.json)
 - Kebab-case CLI args are converted to camelCase internally (e.g., `--name-pattern` → `namePattern`)
 - TAP output flows through stdout; errors and notes through stderr
-- Exit codes: 0 = all pass (incl. coverage goals), 1 = test failure / coverage miss / bail / crash, 2 = invocation error (bad config, e.g. `--coverage=true` without `coverageTargets`)
+- Exit codes: 0 = all pass (incl. coverage goals), 1 = test failure / coverage miss / bail / crash, 2 = invocation error (bad config, e.g. `--coverage=true` without `coverageGoals`)
 - All publishable files listed in `package.json` "files" array

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ x-test — run TAP-compliant browser tests from the command line
                                 not met. See “COVERAGE” below. Default: false.
                                 Only supported with chromium-based clients.
 
+    --root <path>               Disk side of the URL origin — the directory the dev
+                                server serves at “/”. Used to resolve “coverageGoals”
+                                keys on disk. Must be “./”- or “../”-prefixed (e.g.
+                                --root=./build). Default: cwd.
+
     --name-pattern <regex>      Regex pattern to filter tests by name. Tests whose
                                 full path (file > describe > … > it) does not
                                 match are skipped.
@@ -72,19 +77,23 @@ x-test — run TAP-compliant browser tests from the command line
 
   CONFIG FILE
     If ./x-test.config.js exists in the current working directory, it is loaded
-    automatically. CLI flags override config values. Coverage file paths are
-    resolved relative to url origin.
+    automatically. CLI flags override config values.
+
+    `root` is the resource root of the URL origin — the directory the dev
+    server serves at `/`. `coverageGoals` keys are paths inside that root, so
+    they're simultaneously root-relative on disk and origin-relative as URLs
+    (the dev server mirrors the two). Both must be `./`- or `../`-prefixed.
 
       export default {
         url:      'http://127.0.0.1:8080/test/',
+        root:     './src',
         client:   'playwright',
         browser:  'chromium',
         timeout:  30_000,
         coverage: true,
-        coverageBasePath: './public',
-        coverageTargets: {
-          './browser/x-test.js':           { lines: 100 },
-          './browser/x-test-root.js':      { lines: 71 },
+        coverageGoals: {
+          './elements/emoji-picker.js':     { lines: 100 },
+          './elements/subscribe-button.js': { lines:  71 },
         },
       };
 
@@ -190,16 +199,16 @@ supported key:
 ```js
 // x-test.config.js
 export default {
-  // OPTIONAL — disk directory the web server serves as its root.
-  //  `coverageTargets` keys resolve against this on disk. Defaults to
-  //  `process.cwd()`. Set it when the server root isn't cwd (e.g. when
-  //  serving `./public` or `./dist`).
-  coverageBasePath: './public',
+  // OPTIONAL — resource root of the URL origin: the directory the dev server
+  //  serves at `/`. Used to resolve `coverageGoals` keys on disk. Defaults to
+  //  `process.cwd()`. Must be `./`- or `../`-prefixed.
+  root:     './src',
 
-  // REQUIRED when `--coverage=true`. Per-file line-coverage goals.
-  //  Keys are paths relative to `coverageBasePath`. Values are `{ lines: N }`
-  //  where N is the minimum percent (0–100) required for the run to pass.
-  coverageTargets: {
+  // REQUIRED when `--coverage=true`. Per-file line-coverage goals. Keys are
+  //  paths inside `root` — equivalently, the URL path the dev server serves
+  //  the file at. Values are `{ lines: N }` where N is the minimum percent
+  //  (0–100) required for the run to pass.
+  coverageGoals: {
     './src/foo.js':        { lines: 100 },
     './src/bar.js':        { lines:  80 },
     './src/flaky-util.js': { lines:  60 },
@@ -215,7 +224,7 @@ Behavior of each target:
   file is read from disk to give a real denominator, and appears in
   `lcov.info` as all-red so the gap is visible in editor integrations.
 - **In config and not on disk** → `(missing)`, exit 1. Catches typos.
-- `--coverage=true` without any `coverageTargets` is an invocation error
+- `--coverage=true` without any `coverageGoals` is an invocation error
   (exit code `2`).
 
 #### Pragmas
@@ -261,7 +270,7 @@ The TAP summary shows got vs. goal per target:
 
 Coverage uses V8's view of the loaded scripts, so paths and line numbers
 have to match source on disk. Bundlers, minifiers, and TypeScript emit
-rewrite both — `coverageTargets` won't resolve and `lcov.info` line
+rewrite both — `coverageGoals` won't resolve and `lcov.info` line
 numbers won't line up. This feature is intended for small, non-transpiled
 library packages.
 
@@ -283,7 +292,7 @@ environment variables.
 - `0` — all tests passed (and, when `--coverage=true`, all coverage goals met).
 - `1` — a test failed, the plan didn’t match the asserts seen, the browser
   emitted a `Bail out!`, the driver crashed, or a coverage goal was missed.
-- `2` — invocation error (e.g., `--coverage=true` without `coverageTargets`
+- `2` — invocation error (e.g., `--coverage=true` without `coverageGoals`
   in `x-test.config.js`).
 
 ## Configuring Playwright

--- a/test/node/config.test.js
+++ b/test/node/config.test.js
@@ -38,7 +38,7 @@ suite('XTestCliConfig.load', () => {
         url: 'http://host/',
         client: 'playwright',
         coverage: true,
-        coverageTargets: {
+        coverageGoals: {
           './src/a.js': { lines: 90 },
         },
       };
@@ -47,7 +47,7 @@ suite('XTestCliConfig.load', () => {
     assert(cfg.url === 'http://host/');
     assert(cfg.client === 'playwright');
     assert(cfg.coverage === true);
-    assert.deepEqual(cfg.coverageTargets, { './src/a.js': { lines: 90 } });
+    assert.deepEqual(cfg.coverageGoals, { './src/a.js': { lines: 90 } });
   });
 
   test('syntax error propagates', async () => {
@@ -62,34 +62,41 @@ suite('XTestCliConfig.load', () => {
   });
 });
 
-suite('XTestCliConfig.validateCoverageBasePath', () => {
+suite('XTestCliConfig.validateRoot', () => {
   test('undefined is a no-op', () => {
-    XTestCliConfig.validateCoverageBasePath(undefined);
+    XTestCliConfig.validateRoot(undefined);
   });
 
-  test('valid string passes', () => {
-    XTestCliConfig.validateCoverageBasePath('./public');
-    XTestCliConfig.validateCoverageBasePath('/abs/path');
+  test('relative-prefixed strings pass', () => {
+    XTestCliConfig.validateRoot('./public');
+    XTestCliConfig.validateRoot('../sibling/dist');
   });
 
   test('empty string rejected', () => {
-    assert.throws(() => XTestCliConfig.validateCoverageBasePath(''), /non-empty string/);
+    assert.throws(() => XTestCliConfig.validateRoot(''), /non-empty string/);
+  });
+
+  test('absolute and bare paths rejected', () => {
+    // Bare ("public") and absolute ("/abs/path") forms are rejected so output
+    //  formatting stays uniform with `coverageGoals` keys (Node-style `./`).
+    assert.throws(() => XTestCliConfig.validateRoot('/abs/path'), /relative path/);
+    assert.throws(() => XTestCliConfig.validateRoot('public'),    /relative path/);
   });
 
   test('non-string rejected', () => {
-    assert.throws(() => XTestCliConfig.validateCoverageBasePath(42),    /non-empty string/);
-    assert.throws(() => XTestCliConfig.validateCoverageBasePath(null),  /non-empty string/);
-    assert.throws(() => XTestCliConfig.validateCoverageBasePath({}),    /non-empty string/);
+    assert.throws(() => XTestCliConfig.validateRoot(42),    /non-empty string/);
+    assert.throws(() => XTestCliConfig.validateRoot(null),  /non-empty string/);
+    assert.throws(() => XTestCliConfig.validateRoot({}),    /non-empty string/);
   });
 });
 
-suite('XTestCliConfig.validateCoverageTargets', () => {
+suite('XTestCliConfig.validateCoverageGoals', () => {
   test('undefined is a no-op', () => {
-    XTestCliConfig.validateCoverageTargets(undefined);
+    XTestCliConfig.validateCoverageGoals(undefined);
   });
 
   test('valid { lines: N } passes', () => {
-    XTestCliConfig.validateCoverageTargets({
+    XTestCliConfig.validateCoverageGoals({
       './src/a.js': { lines: 100 },
       './src/b.js': { lines: 0 },
       './src/c.js': { lines: 50.5 },
@@ -97,54 +104,69 @@ suite('XTestCliConfig.validateCoverageTargets', () => {
   });
 
   test('non-object root → throws', () => {
-    assert.throws(() => XTestCliConfig.validateCoverageTargets('nope'), /must be an object/);
-    assert.throws(() => XTestCliConfig.validateCoverageTargets([]), /must be an object/);
-    assert.throws(() => XTestCliConfig.validateCoverageTargets(null), /must be an object/);
+    assert.throws(() => XTestCliConfig.validateCoverageGoals('nope'), /must be an object/);
+    assert.throws(() => XTestCliConfig.validateCoverageGoals([]), /must be an object/);
+    assert.throws(() => XTestCliConfig.validateCoverageGoals(null), /must be an object/);
   });
 
   test('non-object entry → throws', () => {
-    assert.throws(() => XTestCliConfig.validateCoverageTargets({ './a.js': 100 }), /must be an object/);
-    assert.throws(() => XTestCliConfig.validateCoverageTargets({ './a.js': null }), /must be an object/);
+    assert.throws(() => XTestCliConfig.validateCoverageGoals({ './a.js': 100 }), /must be an object/);
+    assert.throws(() => XTestCliConfig.validateCoverageGoals({ './a.js': null }), /must be an object/);
   });
 
   test('branches/functions/statements → not yet supported', () => {
     assert.throws(
-      () => XTestCliConfig.validateCoverageTargets({ './a.js': { branches: 50 } }),
+      () => XTestCliConfig.validateCoverageGoals({ './a.js': { branches: 50 } }),
       /'branches' not yet supported/,
     );
     assert.throws(
-      () => XTestCliConfig.validateCoverageTargets({ './a.js': { functions: 90 } }),
+      () => XTestCliConfig.validateCoverageGoals({ './a.js': { functions: 90 } }),
       /'functions' not yet supported/,
     );
     assert.throws(
-      () => XTestCliConfig.validateCoverageTargets({ './a.js': { statements: 80 } }),
+      () => XTestCliConfig.validateCoverageGoals({ './a.js': { statements: 80 } }),
       /'statements' not yet supported/,
     );
   });
 
   test('unknown axis → throws with "unknown axis"', () => {
     assert.throws(
-      () => XTestCliConfig.validateCoverageTargets({ './a.js': { nonsense: 50 } }),
+      () => XTestCliConfig.validateCoverageGoals({ './a.js': { nonsense: 50 } }),
       /unknown axis/,
     );
   });
 
   test('lines out of range → throws', () => {
     assert.throws(
-      () => XTestCliConfig.validateCoverageTargets({ './a.js': { lines: 150 } }),
+      () => XTestCliConfig.validateCoverageGoals({ './a.js': { lines: 150 } }),
       /must be a number in \[0, 100\]/,
     );
     assert.throws(
-      () => XTestCliConfig.validateCoverageTargets({ './a.js': { lines: -1 } }),
+      () => XTestCliConfig.validateCoverageGoals({ './a.js': { lines: -1 } }),
       /must be a number in \[0, 100\]/,
     );
     assert.throws(
-      () => XTestCliConfig.validateCoverageTargets({ './a.js': { lines: 'high' } }),
+      () => XTestCliConfig.validateCoverageGoals({ './a.js': { lines: 'high' } }),
       /must be a number/,
     );
     assert.throws(
-      () => XTestCliConfig.validateCoverageTargets({ './a.js': {} }),
+      () => XTestCliConfig.validateCoverageGoals({ './a.js': {} }),
       /must be a number/,
     );
+  });
+
+  test('keys must be `./`- or `../`-prefixed', () => {
+    // Bare (`a.js`) and absolute (`/a.js`) keys are rejected so the coverage
+    //  table renders Node-style relative paths uniformly with `root`.
+    assert.throws(
+      () => XTestCliConfig.validateCoverageGoals({ 'a.js': { lines: 50 } }),
+      /relative path/,
+    );
+    assert.throws(
+      () => XTestCliConfig.validateCoverageGoals({ '/a.js': { lines: 50 } }),
+      /relative path/,
+    );
+    XTestCliConfig.validateCoverageGoals({ './a.js':  { lines: 50 } });
+    XTestCliConfig.validateCoverageGoals({ '../b.js': { lines: 50 } });
   });
 });

--- a/test/node/coverage.test.js
+++ b/test/node/coverage.test.js
@@ -126,13 +126,13 @@ suite('XTestCliCoverage.computeLineHits — pragmas', () => {
 suite('XTestCliCoverage.gradeCoverage', () => {
   const origin = 'http://host';
 
-  test('all targets met → ok: true', () => {
+  test('all goals met → ok: true', () => {
     const text = 'a;\nb;\nc;';
     const entries = [entry('http://host/src/a.js', text, all(text))];
     const result = XTestCliCoverage.gradeCoverage({
       entries,
       origin,
-      targets: { './src/a.js': { lines: 100 } },
+      goals:   { './src/a.js': { lines: 100 } },
     });
     assert(result.ok === true);
     assert(result.rows.length === 1);
@@ -148,18 +148,18 @@ suite('XTestCliCoverage.gradeCoverage', () => {
     const result = XTestCliCoverage.gradeCoverage({
       entries,
       origin,
-      targets: { './src/a.js': { lines: 100 } },
+      goals:   { './src/a.js': { lines: 100 } },
     });
     assert(result.ok === false);
     assert(result.rows[0].lines.met === false);
     assert(result.rows[0].lines.percent === 50);
   });
 
-  test('missing target file → row flagged missing, not met', () => {
+  test('missing goal file → row flagged missing, not met', () => {
     const result = XTestCliCoverage.gradeCoverage({
       entries: [],
       origin,
-      targets: { './src/missing.js': { lines: 80 } },
+      goals:   { './src/missing.js': { lines: 80 } },
     });
     assert(result.ok === false);
     assert(result.rows[0].lines.missing === true);
@@ -174,7 +174,7 @@ suite('XTestCliCoverage.gradeCoverage', () => {
     const result = XTestCliCoverage.gradeCoverage({
       entries,
       origin,
-      targets: { './src/a.js': { lines: 30 } },
+      goals:   { './src/a.js': { lines: 30 } },
     });
     assert(result.rows[0].lines.percent === 33.33);
     assert(result.rows[0].lines.met === true);
@@ -253,12 +253,12 @@ suite('XTestCliCoverage.synthesizeMissingEntries', () => {
     await rm(dir, { recursive: true, force: true });
   });
 
-  test('returns synthetic entries for targets on disk but not in entries', async () => {
+  test('returns synthetic entries for goals on disk but not in entries', async () => {
     const synthetic = await XTestCliCoverage.synthesizeMissingEntries({
       entries: [],
       origin: 'http://host',
       sourceRoot: dir,
-      targets: { './src/onDisk.js': { lines: 80 } },
+      goals:   { './src/onDisk.js': { lines: 80 } },
     });
     assert(synthetic.length === 1);
     assert(synthetic[0].url === 'http://host/src/onDisk.js');
@@ -266,7 +266,7 @@ suite('XTestCliCoverage.synthesizeMissingEntries', () => {
     assert(synthetic[0].text === 'const a = 1;\nconst b = 2;');
   });
 
-  test('skips targets already present in entries', async () => {
+  test('skips goals already present in entries', async () => {
     const existing = {
       url: 'http://host/src/onDisk.js',
       text: 'const a = 1;',
@@ -276,17 +276,17 @@ suite('XTestCliCoverage.synthesizeMissingEntries', () => {
       entries: [existing],
       origin: 'http://host',
       sourceRoot: dir,
-      targets: { './src/onDisk.js': { lines: 80 } },
+      goals:   { './src/onDisk.js': { lines: 80 } },
     });
     assert(synthetic.length === 0);
   });
 
-  test('silently skips targets that are not on disk either', async () => {
+  test('silently skips goals that are not on disk either', async () => {
     const synthetic = await XTestCliCoverage.synthesizeMissingEntries({
       entries: [],
       origin: 'http://host',
       sourceRoot: dir,
-      targets: { './src/does-not-exist.js': { lines: 80 } },
+      goals:   { './src/does-not-exist.js': { lines: 80 } },
     });
     assert(synthetic.length === 0);
   });
@@ -296,12 +296,12 @@ suite('XTestCliCoverage.synthesizeMissingEntries', () => {
       entries: [],
       origin: 'http://host',
       sourceRoot: dir,
-      targets: { './src/onDisk.js': { lines: 80 } },
+      goals:   { './src/onDisk.js': { lines: 80 } },
     });
     const graded = XTestCliCoverage.gradeCoverage({
       entries: synthetic,
       origin: 'http://host',
-      targets: { './src/onDisk.js': { lines: 80 } },
+      goals:   { './src/onDisk.js': { lines: 80 } },
     });
     assert(graded.ok === false);
     assert(graded.rows[0].lines.missing === false);
@@ -369,14 +369,14 @@ suite('XTestCliCoverage.writeLcov', () => {
     `);
   });
 
-  test('targets filter restricts lcov to configured files only', async () => {
+  test('goals filter restricts lcov to configured files only', async () => {
     const targeted   = entry('http://host/src/app.js',  'x;', all('x;'));
     const untargeted = entry('http://host/test/t.html', 'y;', all('y;'));
     const written = await XTestCliCoverage.writeLcov({
       entries: [targeted, untargeted],
       outDir:  dir,
       origin:  'http://host',
-      targets: { './src/app.js': { lines: 50 } },
+      goals:   { './src/app.js': { lines: 50 } },
     });
     const body = await readFile(written, 'utf8');
     assert(body.includes('SF:http://host/src/app.js\n'));
@@ -393,7 +393,7 @@ suite('XTestCliCoverage.writeLcov', () => {
       entries: [first, second],
       outDir:  dir,
       origin:  'http://host',
-      targets: { './x.js': { lines: 100 } },
+      goals:   { './x.js': { lines: 100 } },
     });
     const body = await readFile(written, 'utf8');
     const records = body.split('end_of_record').filter(s => s.trim() !== '');

--- a/x-test-cli-config.js
+++ b/x-test-cli-config.js
@@ -4,16 +4,31 @@ import { pathToFileURL } from 'node:url';
 /**
  * Loads and validates `x-test.config.js`. All methods are static — nothing
  * stateful lives here, just the config filename and the axis-name allowlists
- * that gate `coverageTargets` entries.
+ * that gate `coverageGoals` entries.
  */
 export class XTestCliConfig {
   static #CONFIG_FILE_NAME = 'x-test.config.js';
 
-  // Axes recognized in `coverageTargets[path]` entries. Only `lines` is graded
+  // Axes recognized in `coverageGoals[path]` entries. Only `lines` is graded
   //  in this increment; the other names exist so we can reject them loudly
   //  instead of silently accepting unimplemented config.
   static #SUPPORTED_AXES   = ['lines'];
   static #UNSUPPORTED_AXES = ['functions', 'branches', 'statements'];
+
+  // Relative-path prefixes we require on `root` and `coverageGoals` keys.
+  //  Picks one shape and enforces it so users can't accidentally mix
+  //  bare/absolute/`./`-prefixed paths in their config.
+  static #RELATIVE_PREFIXES = ['./', '../'];
+
+  /** Common guard: reject anything that isn't a `./`- or `../`-prefixed string. */
+  static #assertRelative(value, label) {
+    if (typeof value !== 'string' || value === '') {
+      throw new Error(`${label} must be a non-empty string, got ${XTestCliConfig.#describe(value)}.`);
+    }
+    if (!XTestCliConfig.#RELATIVE_PREFIXES.some(p => value.startsWith(p))) {
+      throw new Error(`${label} must be a relative path starting with './' or '../', got ${JSON.stringify(value)}.`);
+    }
+  }
 
   /**
    * Load `x-test.config.js` from `cwd`. Returns the module's default export,
@@ -34,48 +49,49 @@ export class XTestCliConfig {
   }
 
   /**
-   * Validate `coverageBasePath` — the disk directory the web server serves as
-   * its root. `coverageTargets` keys resolve against it on disk. Paired in name
-   * with a future `coverageBaseUrl` (URL side). Must be a non-empty string when
-   * present; anything else fails loud.
+   * Validate `root` — the disk directory the dev server serves as its root.
+   * Used both to resolve `coverageGoals` keys against disk and to rewrite
+   * stack-trace URLs in synthesized failure output. Must be a `./`- or
+   * `../`-prefixed string when present; bare names and absolute paths fail
+   * loud so output formatting stays consistent across consumers.
    */
-  static validateCoverageBasePath(coverageBasePath) {
-    if (coverageBasePath === undefined) {
+  static validateRoot(root) {
+    if (root === undefined) {
       return;
     }
-    if (typeof coverageBasePath !== 'string' || coverageBasePath === '') {
-      throw new Error(`coverageBasePath must be a non-empty string, got ${XTestCliConfig.#describe(coverageBasePath)}.`);
-    }
+    XTestCliConfig.#assertRelative(root, 'root');
   }
 
   /**
-   * Validate `coverageTargets` shape. Throws with a path-qualified message on
-   * the first problem found. Accepts only `{ lines: <number 0..100> }` per
-   * entry; unknown axes throw "not yet supported" so future additions are a
-   * deliberate choice, not a silent config drift.
+   * Validate `coverageGoals` shape. Throws with a path-qualified message on
+   * the first problem found. Keys must be `./`- or `../`-prefixed paths;
+   * values accept only `{ lines: <number 0..100> }`. Unknown axes throw "not
+   * yet supported" so future additions are a deliberate choice, not a silent
+   * config drift.
    */
-  static validateCoverageTargets(targets) {
-    if (targets === undefined) {
+  static validateCoverageGoals(goals) {
+    if (goals === undefined) {
       return;
     }
-    if (targets === null || typeof targets !== 'object' || Array.isArray(targets)) {
-      throw new Error(`coverageTargets must be an object, got ${XTestCliConfig.#describe(targets)}.`);
+    if (goals === null || typeof goals !== 'object' || Array.isArray(goals)) {
+      throw new Error(`coverageGoals must be an object, got ${XTestCliConfig.#describe(goals)}.`);
     }
-    for (const [path, entry] of Object.entries(targets)) {
+    for (const [path, entry] of Object.entries(goals)) {
+      XTestCliConfig.#assertRelative(path, `coverageGoals key ${JSON.stringify(path)}`);
       if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
-        throw new Error(`coverageTargets[${JSON.stringify(path)}] must be an object, got ${XTestCliConfig.#describe(entry)}.`);
+        throw new Error(`coverageGoals[${JSON.stringify(path)}] must be an object, got ${XTestCliConfig.#describe(entry)}.`);
       }
       for (const axis of Object.keys(entry)) {
         if (XTestCliConfig.#UNSUPPORTED_AXES.includes(axis)) {
-          throw new Error(`coverageTargets[${JSON.stringify(path)}]: '${axis}' not yet supported (only 'lines').`);
+          throw new Error(`coverageGoals[${JSON.stringify(path)}]: '${axis}' not yet supported (only 'lines').`);
         }
         if (!XTestCliConfig.#SUPPORTED_AXES.includes(axis)) {
-          throw new Error(`coverageTargets[${JSON.stringify(path)}]: unknown axis '${axis}' (only 'lines').`);
+          throw new Error(`coverageGoals[${JSON.stringify(path)}]: unknown axis '${axis}' (only 'lines').`);
         }
       }
       const { lines } = entry;
       if (typeof lines !== 'number' || !Number.isFinite(lines) || lines < 0 || lines > 100) {
-        throw new Error(`coverageTargets[${JSON.stringify(path)}].lines must be a number in [0, 100], got ${XTestCliConfig.#describe(lines)}.`);
+        throw new Error(`coverageGoals[${JSON.stringify(path)}].lines must be a number in [0, 100], got ${XTestCliConfig.#describe(lines)}.`);
       }
     }
   }

--- a/x-test-cli-coverage.js
+++ b/x-test-cli-coverage.js
@@ -76,21 +76,20 @@ export class XTestCliCoverage {
   }
 
   /**
-   * Grade the configured `targets` against the collected V8 `entries`. Targets
+   * Grade the configured `goals` against the collected V8 `entries`. Goal paths
    * are resolved against `origin` (the test URL’s origin) using the standard
-   * URL-base algorithm, so `'./src/foo.js'` maps to
-   * `http://<origin>/src/foo.js` — which is exactly the form V8 reports for
-   * scripts served by the test harness.
+   * URL-base algorithm, `'./src/foo.js'` maps to `http://<origin>/src/foo.js` —
+   * which is exactly the form V8 reports for the served scripts.
    *
-   * Returns `{ ok, rows }`. `ok` is true iff every target met its goal.
+   * Returns `{ ok, rows }`. `ok` is true iff every goal was met.
    */
-  static gradeCoverage({ entries, origin, targets }) {
+  static gradeCoverage({ entries, origin, goals }) {
     // Duplicate entries (same URL, different executions) merge into one so a
     //  file loaded twice is graded on the union of its observed coverage, not
     //  on whichever execution happened to be first in the list.
-    const prepared = XTestCliCoverage.#filterAndMerge(entries, origin, targets);
+    const prepared = XTestCliCoverage.#filterAndMerge(entries, origin, goals);
     const rows = [];
-    for (const [path, spec] of Object.entries(targets)) {
+    for (const [path, spec] of Object.entries(goals)) {
       const resolvedUrl = new URL(path, origin + '/').href;
       const entry = prepared.find(item => item.url === resolvedUrl);
       if (!entry) {
@@ -127,21 +126,21 @@ export class XTestCliCoverage {
   }
 
   /**
-   * Produce synthetic V8-shape entries for `coverageTargets` that the browser
+   * Produce synthetic V8-shape entries for `coverageGoals` that the browser
    * never loaded but which exist on disk. This lets a file listed in config but
    * not actually imported by the test page fail the grading gracefully with
    * `0.0 / goal  not ok` rather than a terse “missing” notation — and also
    * makes the file show up in `lcov.info` with all lines red, which is the
    * honest signal for “you said to cover this but it never ran.”
    *
-   * Targets that match no V8 entry AND don’t exist on disk fall through to
+   * Goals that match no V8 entry AND don’t exist on disk fall through to
    * `gradeCoverage`’s `missing` path, which keeps the explicit “file not
    * found” notation for true typos in config.
    */
-  static async synthesizeMissingEntries({ entries, origin, sourceRoot, targets }) {
+  static async synthesizeMissingEntries({ entries, origin, sourceRoot, goals }) {
     const known = new Set(entries.map(item => item.url));
     const synthetic = [];
-    for (const path of Object.keys(targets ?? {})) {
+    for (const path of Object.keys(goals ?? {})) {
       const resolvedUrl = new URL(path, origin + '/').href;
       if (known.has(resolvedUrl)) {
         continue;
@@ -151,8 +150,8 @@ export class XTestCliCoverage {
         const text = await readFile(diskPath, 'utf8');
         synthetic.push({ url: resolvedUrl, text, ranges: [] });
       } catch {
-        // Target doesn’t exist on disk either — leave it to gradeCoverage’s
-        //  “missing” path so the row shows “file not found”.
+        // Goal’s file doesn’t exist on disk either — leave it to
+        //  gradeCoverage’s “missing” path so the row shows “file not found”.
       }
     }
     return synthetic;
@@ -160,7 +159,7 @@ export class XTestCliCoverage {
 
   /**
    * Write `lcov.info` into `outDir` (created if necessary). Only entries
-   * matching a `coverageTargets` URL are emitted — lcov should describe what
+   * matching a `coverageGoals` URL are emitted — lcov should describe what
    * the user asked to cover, nothing more, so editor integrations don’t show
    * coverage for test harness files or ad-hoc imports.
    *
@@ -176,11 +175,11 @@ export class XTestCliCoverage {
    *
    * Resolves to the absolute path written.
    */
-  static async writeLcov({ entries, outDir, origin, sourceRoot, targets }) {
+  static async writeLcov({ entries, outDir, origin, sourceRoot, goals }) {
     const dir = resolvePath(outDir);
     await mkdir(dir, { recursive: true });
     const path = resolvePath(dir, 'lcov.info');
-    const prepared = XTestCliCoverage.#filterAndMerge(entries, origin, targets);
+    const prepared = XTestCliCoverage.#filterAndMerge(entries, origin, goals);
     await writeFile(path, XTestCliCoverage.#formatLcov(prepared, { origin, sourceRoot }));
     return path;
   }
@@ -435,7 +434,7 @@ export class XTestCliCoverage {
   }
 
   /**
-   * Narrow `entries` to just the URLs named in `coverageTargets` (if any) and
+   * Narrow `entries` to just the URLs named in `coverageGoals` (if any) and
    * collapse duplicate-URL entries into one with the union of their ranges.
    *
    * The deduping matters because V8 emits a separate entry per script load — a
@@ -444,13 +443,13 @@ export class XTestCliCoverage {
    * overlapping spans: `#coverageMap` ORs them together, so any overlap is
    * already handled correctly at the byte level.
    */
-  static #filterAndMerge(entries, origin, targets) {
-    const targetUrls = (targets && origin)
-      ? new Set(Object.keys(targets).map(path => new URL(path, origin + '/').href))
+  static #filterAndMerge(entries, origin, goals) {
+    const goalUrls = (goals && origin)
+      ? new Set(Object.keys(goals).map(path => new URL(path, origin + '/').href))
       : null;
     const byUrl = new Map();
     for (const entry of entries) {
-      if (targetUrls && !targetUrls.has(entry.url)) {
+      if (goalUrls && !goalUrls.has(entry.url)) {
         continue;
       }
       const existing = byUrl.get(entry.url);

--- a/x-test-cli.js
+++ b/x-test-cli.js
@@ -13,7 +13,7 @@ const SUPPORTED_REPORTERS = ['tap', 'auto'];
 
 // Value-taking flags (always `--key=value`). `--help` and `--version` are
 //  handled as bare flags in the early-exit block below, so they’re not here.
-const ALLOWED_ARGS = ['client', 'url', 'coverage', 'name-pattern', 'reporter', 'timeout'];
+const ALLOWED_ARGS = ['client', 'url', 'root', 'coverage', 'name-pattern', 'reporter', 'timeout'];
 const ALLOWED_ARGS_DEBUG = ALLOWED_ARGS.map(arg => `"--${arg}"`).join(', ');
 
 const HELP = `\
@@ -40,6 +40,11 @@ x-test — run TAP-compliant browser tests from the command line
                                 not met. See “COVERAGE” below. Default: false.
                                 Only supported with chromium-based clients.
 
+    --root <path>               Resource root of the URL origin — the directory the
+                                dev server serves at “/”. Used to resolve
+                                “coverageGoals” keys on disk. Must be “./”- or
+                                “../”-prefixed (e.g. --root=./build). Default: cwd.
+
     --name-pattern <regex>      Regex pattern to filter tests by name. Tests whose
                                 full path (file > describe > … > it) does not
                                 match are skipped.
@@ -56,19 +61,23 @@ x-test — run TAP-compliant browser tests from the command line
 
   CONFIG FILE
     If ./x-test.config.js exists in the current working directory, it is loaded
-    automatically. CLI flags override config values. Coverage file paths are
-    resolved relative to url origin.
+    automatically. CLI flags override config values.
+
+    The “root” arg is the resource root of the URL origin — the directory the dev
+    server serves at “/”. “coverageGoals” keys are paths inside that root, so
+    they’re simultaneously root-relative on disk and origin-relative as URLs
+    (the dev server mirrors the two). Both must be “./”- or “../”-prefixed.
 
       export default {
         url:      'http://127.0.0.1:8080/test/',
+        root:     './src',
         client:   'playwright',
         browser:  'chromium',
         timeout:  30_000,
         coverage: true,
-        coverageBasePath: './public',
-        coverageTargets: {
-          './browser/x-test.js':           { lines: 100 },
-          './browser/x-test-root.js':      { lines: 71 },
+        coverageGoals: {
+          './elements/emoji-picker.js':      { lines: 100 },
+          './elements/subscribe-button.js':  { lines:  71 },
         },
       };
 
@@ -98,7 +107,7 @@ x-test — run TAP-compliant browser tests from the command line
     initiate tests via “x-test-cli”. The “--name-pattern” CLI argument
     maps to a browser-side “?x-test-name-pattern” search param on the
     resulting test page.
- 
+
   EXAMPLES
     # Run with defaults from x-test.config.js
     x-test
@@ -124,7 +133,7 @@ x-test — run TAP-compliant browser tests from the command line
 // Exit code 2 is reserved for invocation errors where the request itself is
 //  malformed — distinct from a passing-but-not-ok run (1) or a successful
 //  run (0). Only one path claims it this increment: `--coverage` without
-//  `coverageTargets`. Other invocation errors still use 1 until a later
+//  `coverageGoals`. Other invocation errors still use 1 until a later
 //  increment restructures the exit-code surface.
 function fail(message, code = 1) {
   console.error(message); // eslint-disable-line no-console
@@ -201,16 +210,24 @@ if (options.coverage === true || options.coverage === 'true') {
   fail(`Error: --coverage must be "true" or "false", got "${options.coverage}".`);
 }
 
-// Coverage requires goals. Without `coverageTargets` there is nothing to
+// The `root` argument is validated unconditionally — bare/absolute paths are
+//  config-shape errors regardless of whether coverage is on. The 
+//  `coverageGoals` config only matters with coverage, so it stays gated.
+try {
+  XTestCliConfig.validateRoot(options.root);
+} catch (error) {
+  fail(`Error: ${error.message}`, 2);
+}
+
+// Coverage requires goals. Without `coverageGoals` there is nothing to
 //  grade against — treat as an invocation error so misconfiguration fails
 //  loud instead of silently reporting “all ok”.
-if (coverage && !options.coverageTargets) {
-  fail('Error: --coverage=true requires coverageTargets in x-test.config.js.', 2);
+if (coverage && !options.coverageGoals) {
+  fail('Error: --coverage=true requires coverageGoals in x-test.config.js.', 2);
 }
 if (coverage) {
   try {
-    XTestCliConfig.validateCoverageBasePath(options.coverageBasePath);
-    XTestCliConfig.validateCoverageTargets(options.coverageTargets);
+    XTestCliConfig.validateCoverageGoals(options.coverageGoals);
   } catch (error) {
     fail(`Error: ${error.message}`, 2);
   }
@@ -321,35 +338,36 @@ let coverageOk = true;
 if (coverage && rawCoverageEntries) {
   try {
     const origin = new URL(url).origin;
-    // `coverageBasePath` (config) is the disk directory the web server serves
-    //  as its root — the directory target paths resolve against. Defaults to
-    //  cwd. Set this when the server root isn’t cwd (e.g. serving `./public`
-    //  or `./dist`), otherwise synthesis-from-disk and lcov `SF:` will point
-    //  at the wrong files.
-    const sourceRoot = options.coverageBasePath
-      ? resolve(process.cwd(), options.coverageBasePath)
+    // The `root` (config) is the disk directory the dev server serves as its
+    //  root — the directory goal paths resolve against. Defaults to cwd.
+    //  Set this when the server root isn’t cwd (e.g. serving `./src` or
+    //  `./dist`), otherwise synthesis-from-disk and lcov `SF:` will point at
+    //  the wrong files.
+    const sourceRoot = options.root
+      ? resolve(process.cwd(), options.root)
       : process.cwd();
-    // Synthesize entries for targets the browser never loaded but that exist
-    //  on disk — so the summary shows `0.0 / goal  not ok` for a real denominator
-    //  and lcov shows the file as all-red, rather than a terse “missing” notation.
+    // Synthesize entries for goal files the browser never loaded but that
+    //  exist on disk — so the summary shows `0.0 / goal  not ok` with a real
+    //  denominator and lcov shows the file all-red, rather than a terse
+    //  “missing” notation.
     const synthetic = await XTestCliCoverage.synthesizeMissingEntries({
       entries: rawCoverageEntries,
       origin,
       sourceRoot,
-      targets: options.coverageTargets,
+      goals:   options.coverageGoals,
     });
     const allEntries = [...rawCoverageEntries, ...synthetic];
     const lcovAbsolute = await XTestCliCoverage.writeLcov({
       entries: allEntries,
       outDir:  './coverage',
-      origin,                           // In-origin entries map to on-disk paths.
+      origin,                          // In-origin entries map to on-disk paths.
       sourceRoot,
-      targets: options.coverageTargets, // Only targeted files appear in lcov.
+      goals:   options.coverageGoals,  // Only goal files appear in lcov.
     });
     const graded = XTestCliCoverage.gradeCoverage({
       entries: allEntries,
       origin,
-      targets: options.coverageTargets,
+      goals:   options.coverageGoals,
     });
     coverageOk = graded.ok;
     tap.writeCoverage(XTestCliCoverage.formatCoverageBlock({ result: graded, lcovPath: displayPath(lcovAbsolute) }));

--- a/x-test.config.js
+++ b/x-test.config.js
@@ -1,6 +1,6 @@
 // Dev-only coverage config for this repo’s integration test.
 export default {
-  coverageTargets: {
+  coverageGoals: {
     // Dummy module under test — imported by `test/browser/main.js`,
     //  exercised partially so the summary shows a meaningful number.
     './test/browser/subject.js': { lines: 50 },


### PR DESCRIPTION
Changes:
- Renames `coverageBasePath` to `root`. It’s simpler and will impact things beyond just coverage.
- Exposes related `--root` argument (e.g., run tests against /build).
- Enforces relative file naming in config file — can always relax later.
- Renames `coverageTargets` to `coverageGoals`, shorter / simpler.