### PR TITLE
Re-emit failures from CLI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `# Failures:` block is now synthesized by the CLI from the streamed TAP
+  rather than re-iterated by the in-browser test runner. Stack-trace URLs
+  are rewritten to bare cwd-relative paths so modern terminals can just resolve
+  them as local files (#22).
 - `--root=<path>` CLI flag. Mirrors the config key for ad-hoc overrides
   (e.g. `--root=./build` to point at a vite-built dist without editing
   config). Validated unconditionally (#22).

--- a/demo/color.js
+++ b/demo/color.js
@@ -13,5 +13,11 @@ if (!file) {
   process.exit(0);
 }
 
-const tap = new XTestCliTap({ stream: process.stdout, color: true });
+const tap = new XTestCliTap({
+  stream:     process.stdout,
+  color:      true,
+  baseUrl:    'http://127.0.0.1:8080/',
+  sourceRoot: process.cwd() + '/',
+  cwd:        process.cwd() + '/',
+});
 tap.write(readFileSync(file, 'utf8'));

--- a/demo/fixtures/failures.tap
+++ b/demo/fixtures/failures.tap
@@ -1,0 +1,37 @@
+TAP version 14
+# Subtest: http://127.0.0.1:8080/test/browser/index.html
+    # Subtest: failure re-iteration block
+        ok 1 - styles trailer comments red
+        not ok 2 - emits the synthesized block on plan
+          ---
+          message: not ok
+          severity: fail
+          stack: |-
+            Error: not ok
+                at XTestCliTap.#emitFailureBlock (http://127.0.0.1:8080/x-test-cli-tap.js:200:5)
+                at XTestCliTap.#finalize (http://127.0.0.1:8080/x-test-cli-tap.js:184:10)
+                at XTestCliTap.#processLine (http://127.0.0.1:8080/x-test-cli-tap.js:380:7)
+                at http://127.0.0.1:8080/test/node/tap.test.js:715:5
+          ...
+        1..2
+    not ok 1 - failure re-iteration block
+    1..1
+not ok 1 - http://127.0.0.1:8080/test/browser/index.html
+# Subtest: http://127.0.0.1:8080/test/browser/index.html
+    # Subtest: lcov writer
+        not ok 1 - writes one record per targeted file
+          ---
+          message: not ok
+          severity: fail
+          stack: |-
+            Error: not ok
+                at writeLcov (http://127.0.0.1:8080/x-test-cli-coverage.js:120:9)
+                at http://127.0.0.1:8080/x-test-cli.js:343:33
+                at MessagePort.<anonymous> (node:internal/worker:284:11)
+                at fetch (https://cdn.example.com/vendor/lib.js:42:9)
+          ...
+        1..1
+    not ok 1 - lcov writer
+    1..1
+not ok 2 - http://127.0.0.1:8080/test/browser/index.html
+1..2

--- a/demo/tap.js
+++ b/demo/tap.js
@@ -14,5 +14,16 @@ if (!file) {
   process.exit(0);
 }
 
-const tap = new XTestCliTap({ stream: process.stdout, color: false });
+// Mirror the CLI's runtime behavior: rewrite the demo origin to bare cwd-
+//  relative paths in the synthesized `# Failures:` block. Modern terminals
+//  (VSCode, iTerm2 with cwd tracking, Ghostty) click-resolve `path:line:col`
+//  against shell cwd. Fixtures whose stack frames don't reference this origin
+//  pass through untouched.
+const tap = new XTestCliTap({
+  stream:     process.stdout,
+  color:      false,
+  baseUrl:    'http://127.0.0.1:8080/',
+  sourceRoot: process.cwd() + '/',
+  cwd:        process.cwd() + '/',
+});
 tap.write(readFileSync(file, 'utf8'));

--- a/test/node/coverage.test.js
+++ b/test/node/coverage.test.js
@@ -182,7 +182,7 @@ suite('XTestCliCoverage.gradeCoverage', () => {
 });
 
 suite('XTestCliCoverage.formatCoverageBlock', () => {
-  test('full shape: header, blank, rows, blank, trailer', () => {
+  test('full shape: header, blank, rows', () => {
     const result = {
       ok: false,
       rows: [
@@ -194,12 +194,8 @@ suite('XTestCliCoverage.formatCoverageBlock', () => {
       # Coverage:
       #
       # not ok - 65%  line coverage goal (got 60.61%) | ./src/reporter.js
-      # ok     - 100% line coverage goal (got 100%)   | ./src/x-test.js
-      #
-      # (see ./coverage/lcov.info)`;
-    assert(
-      XTestCliCoverage.formatCoverageBlock({ result, lcovPath: './coverage/lcov.info' }) === expected,
-    );
+      # ok     - 100% line coverage goal (got 100%)   | ./src/x-test.js`;
+    assert(XTestCliCoverage.formatCoverageBlock({ result }) === expected);
   });
 
   test('missing row uses "(missing)" where (got N%) would go', () => {
@@ -212,10 +208,8 @@ suite('XTestCliCoverage.formatCoverageBlock', () => {
     const expected = dedent`
       # Coverage:
       #
-      # not ok - 80% line coverage goal (missing) | ./src/missing.js
-      #
-      # (see x)`;
-    assert(XTestCliCoverage.formatCoverageBlock({ result, lcovPath: 'x' }) === expected);
+      # not ok - 80% line coverage goal (missing) | ./src/missing.js`;
+    assert(XTestCliCoverage.formatCoverageBlock({ result }) === expected);
   });
 
   test('percent trims trailing zeros but keeps two-decimal precision', () => {
@@ -233,10 +227,8 @@ suite('XTestCliCoverage.formatCoverageBlock', () => {
       #
       # ok - 50%  line coverage goal (got 60.6%)  | a
       # ok - 50%  line coverage goal (got 60.63%) | b
-      # ok - 100% line coverage goal (got 100%)   | c
-      #
-      # (see x)`;
-    assert(XTestCliCoverage.formatCoverageBlock({ result, lcovPath: 'x' }) === expected);
+      # ok - 100% line coverage goal (got 100%)   | c`;
+    assert(XTestCliCoverage.formatCoverageBlock({ result }) === expected);
   });
 });
 

--- a/test/node/tap.test.js
+++ b/test/node/tap.test.js
@@ -23,6 +23,15 @@ const styles = {
   cyan:    '\x1b[36m',
 };
 
+// XTestCliTap requires baseUrl/sourceRoot/cwd. Tests that don't exercise URL
+//  rewriting pass these sentinels — non-matching strings (with trailing `/`
+//  per XTestCliTap's contract) so the rewrite is a no-op on test inputs.
+const NOOP_URL_MAP = {
+  baseUrl:    'http://__test_no_rewrite__/',
+  sourceRoot: '/__test_no_rewrite__/',
+  cwd:        '/__test_no_rewrite__/',
+};
+
 
 suite('result accumulation', () => {
   test('plan + passes → ok', () => {
@@ -32,7 +41,7 @@ suite('result accumulation', () => {
       ok 2 - b
       1..2
     `;
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write(text);
     assert.deepEqual(tap.result, {
       ok: true,
@@ -55,7 +64,7 @@ suite('result accumulation', () => {
       not ok 1 - broken
       1..1
     `;
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write(text);
     assert.deepEqual(tap.result, {
       ok: false,
@@ -79,7 +88,7 @@ suite('result accumulation', () => {
       ok 2
       1..3
     `;
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write(text);
     assert.deepEqual(tap.result, {
       ok: false,
@@ -101,7 +110,7 @@ suite('result accumulation', () => {
       TAP version 14
       1..0
     `;
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write(text);
     assert.deepEqual(tap.result, {
       ok: true,
@@ -128,7 +137,7 @@ suite('result accumulation', () => {
       1..0
       ok 1 - surprise
     `;
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write(text);
     assert.deepEqual(tap.result, {
       ok:         true,
@@ -155,7 +164,7 @@ suite('result accumulation', () => {
       ok 1 - group
       1..1
     `;
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write(text);
     const result = tap.result;
     // Only the top-level `ok 1 - group` should count. The inner asserts
@@ -185,7 +194,7 @@ suite('result accumulation', () => {
       ok 1 - group
       1..1
     `;
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write(text);
     assert.deepEqual(tap.result, {
       ok: true,
@@ -229,7 +238,7 @@ suite('result accumulation', () => {
       ok 2 - http://host/b/
       1..2
     `;
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write(text);
     assert.deepEqual(tap.result, {
       ok: true,
@@ -251,7 +260,7 @@ suite('result accumulation', () => {
       TAP version 14
       Bail out! launch timeout
     `;
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write(text);
     assert.deepEqual(tap.result, {
       ok: false,
@@ -274,7 +283,7 @@ suite('result accumulation', () => {
       ok 1 plain description
       1..1
     `;
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write(text);
     assert.deepEqual(tap.result, {
       ok: true,
@@ -297,7 +306,7 @@ suite('result accumulation', () => {
       ok
       1..1
     `;
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write(text);
     assert.deepEqual(tap.result, {
       ok: true,
@@ -322,7 +331,7 @@ suite('directives', () => {
       not ok 1 - pending # TODO later
       1..1
     `;
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write(text);
     assert.deepEqual(tap.result, {
       ok: true,
@@ -345,7 +354,7 @@ suite('directives', () => {
       ok 1 - feature # SKIP not supported
       1..1
     `;
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write(text);
     assert.deepEqual(tap.result, {
       ok: true,
@@ -378,7 +387,7 @@ suite('passthrough (color off) is byte-identical', () => {
       1..4
     `;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: false });
+    const tap = new XTestCliTap({ stream, color: false, ...NOOP_URL_MAP });
     tap.write(text);
     const out = stream.read().toString();
     assert(out === text);
@@ -393,7 +402,7 @@ suite('passthrough (color off) is byte-identical', () => {
         ...
     `;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: false });
+    const tap = new XTestCliTap({ stream, color: false, ...NOOP_URL_MAP });
     tap.write(text);
     const out = stream.read().toString();
     assert(out === text);
@@ -411,7 +420,7 @@ suite('passthrough (color off) is byte-identical', () => {
       1..3
     `;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
+    const tap = new XTestCliTap({ stream, color: true, ...NOOP_URL_MAP });
     tap.write(text);
     const out = stream.read().toString();
     assert(stripAnsi(out) === text);
@@ -429,7 +438,7 @@ suite('colorization', () => {
       ${styles.green}ok 1 - alpha${styles.reset}
     `;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
+    const tap = new XTestCliTap({ stream, color: true, ...NOOP_URL_MAP });
     tap.write(text);
     const out = stream.read().toString();
     assert(out === stylized);
@@ -446,7 +455,7 @@ suite('colorization', () => {
       ${styles.red}not ok 2 - boom${styles.reset}
     `;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
+    const tap = new XTestCliTap({ stream, color: true, ...NOOP_URL_MAP });
     tap.write(text);
     const out = stream.read().toString();
     assert(out === stylized);
@@ -463,7 +472,7 @@ suite('colorization', () => {
       ${styles.orange}ok 1 - feature # SKIP nope${styles.reset}
     `;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
+    const tap = new XTestCliTap({ stream, color: true, ...NOOP_URL_MAP });
     tap.write(text);
     const out = stream.read().toString();
     assert(out === stylized);
@@ -480,7 +489,7 @@ suite('colorization', () => {
       ${styles.orange}not ok 1 - pending # TODO later${styles.reset}
     `;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
+    const tap = new XTestCliTap({ stream, color: true, ...NOOP_URL_MAP });
     tap.write(text);
     const out = stream.read().toString();
     assert(out === stylized);
@@ -497,7 +506,7 @@ suite('colorization', () => {
       ${styles.yellow}ok 1 - surprise # TODO meant to fail${styles.reset}
     `;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
+    const tap = new XTestCliTap({ stream, color: true, ...NOOP_URL_MAP });
     tap.write(text);
     const out = stream.read().toString();
     assert(out === stylized);
@@ -514,7 +523,7 @@ suite('colorization', () => {
       ${styles.boldRed}Bail out! launch timeout${styles.reset}
     `;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
+    const tap = new XTestCliTap({ stream, color: true, ...NOOP_URL_MAP });
     tap.write(text);
     const out = stream.read().toString();
     assert(out === stylized);
@@ -525,7 +534,7 @@ suite('colorization', () => {
     const text = `TAP version 14\n    # Subtest: render\n`;
     const stylized = `${styles.dim}TAP version 14${styles.reset}\n${styles.cyan}    # Subtest: render${styles.reset}\n`;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
+    const tap = new XTestCliTap({ stream, color: true, ...NOOP_URL_MAP });
     tap.write(text);
     const out = stream.read().toString();
     assert(out === stylized);
@@ -542,7 +551,7 @@ suite('colorization', () => {
       ${styles.dim}1..3${styles.reset}
     `;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
+    const tap = new XTestCliTap({ stream, color: true, ...NOOP_URL_MAP });
     tap.write(text);
     const out = stream.read().toString();
     assert(out === stylized);
@@ -565,7 +574,7 @@ suite('colorization', () => {
       ${styles.green}ok 1 - after${styles.reset}
     `;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
+    const tap = new XTestCliTap({ stream, color: true, ...NOOP_URL_MAP });
     tap.write(text);
     const out = stream.read().toString();
     assert(out === stylized);
@@ -576,7 +585,7 @@ suite('colorization', () => {
     const text = `TAP version 14\n        ok 1 - deep\n`;
     const stylized = `${styles.dim}TAP version 14${styles.reset}\n${styles.green}        ok 1 - deep${styles.reset}\n`;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
+    const tap = new XTestCliTap({ stream, color: true, ...NOOP_URL_MAP });
     tap.write(text);
     const out = stream.read().toString();
     assert(out === stylized);
@@ -585,301 +594,331 @@ suite('colorization', () => {
 });
 
 suite('coverage summary', () => {
-  test('# Coverage: header → dim', () => {
-    const text = '# Coverage:\n';
-    const stylized = `${styles.dim}# Coverage:${styles.reset}\n`;
+  const sample = dedent`
+    # Coverage:
+    #
+    # ok     - 100% line coverage goal (got 100%)   | ./src/foo.js
+    # not ok - 65%  line coverage goal (got 60.64%) | ./src/bar.js
+  `;
+
+  test('ok=true → every line dim', () => {
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
-    tap.writeCoverage(text);
+    const tap = new XTestCliTap({ stream, color: true, ...NOOP_URL_MAP });
+    tap.writeCoverage(sample, { ok: true });
     const out = stream.read().toString();
-    assert(out === stylized);
-    assert(stripAnsi(out) === text);
+    for (const line of out.split('\n').filter(l => l.length > 0)) {
+      assert(line.startsWith(styles.dim));
+    }
+    assert(stripAnsi(out) === sample);
   });
 
-  test('coverage row starting with "ok" → green', () => {
-    const text = '# ok     - 100% line coverage goal (got 100%)   | ./src/foo.js\n';
-    const stylized = `${styles.green}# ok     - 100% line coverage goal (got 100%)   | ./src/foo.js${styles.reset}\n`;
+  test('ok=false → every line red', () => {
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
-    tap.writeCoverage(text);
+    const tap = new XTestCliTap({ stream, color: true, ...NOOP_URL_MAP });
+    tap.writeCoverage(sample, { ok: false });
     const out = stream.read().toString();
-    assert(out === stylized);
-    assert(stripAnsi(out) === text);
-  });
-
-  test('coverage row starting with "not ok" → red', () => {
-    const text = '# not ok - 65%  line coverage goal (got 60.64%) | ./src/bar.js\n';
-    const stylized = `${styles.red}# not ok - 65%  line coverage goal (got 60.64%) | ./src/bar.js${styles.reset}\n`;
-    const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
-    tap.writeCoverage(text);
-    const out = stream.read().toString();
-    assert(out === stylized);
-    assert(stripAnsi(out) === text);
-  });
-
-  test('# (see ...) trailer → dim', () => {
-    const text = '# (see ./coverage/lcov.info)\n';
-    const stylized = `${styles.dim}# (see ./coverage/lcov.info)${styles.reset}\n`;
-    const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
-    tap.writeCoverage(text);
-    const out = stream.read().toString();
-    assert(out === stylized);
-    assert(stripAnsi(out) === text);
-  });
-
-  test('blank `#` separator → dim', () => {
-    const text = '#\n';
-    const stylized = `${styles.dim}#${styles.reset}\n`;
-    const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
-    tap.writeCoverage(text);
-    const out = stream.read().toString();
-    assert(out === stylized);
-    assert(stripAnsi(out) === text);
-  });
-
-  test('unknown lines inside a coverage block render raw', () => {
-    // Anything the four coverage patterns don't classify slips through
-    //  without style. Keeps the method forgiving about surprise content.
-    const text = 'garbage line here\n';
-    const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
-    tap.writeCoverage(text);
-    const out = stream.read().toString();
-    assert(out === text);
+    for (const line of out.split('\n').filter(l => l.length > 0)) {
+      assert(line.startsWith(styles.red));
+    }
+    assert(stripAnsi(out) === sample);
   });
 
   test('coverage block renders raw when color is off', () => {
-    const text = dedent`
-      # Coverage:
-      #
-      # ok     - 100% line coverage goal (got 100%)   | ./src/foo.js
-      # not ok - 65%  line coverage goal (got 60.64%) | ./src/bar.js
-      #
-      # (see ./coverage/lcov.info)
-    `;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: false });
-    tap.writeCoverage(text);
+    const tap = new XTestCliTap({ stream, color: false, ...NOOP_URL_MAP });
+    tap.writeCoverage(sample, { ok: true });
     const out = stream.read().toString();
-    assert(out === text);
+    assert(out === sample);
   });
 
   test('writeCoverage does not mutate tap.result', () => {
     // The coverage block arrives after auto-end; writeCoverage is a
     //  separate rendering path that never touches the parser state.
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
+    tap.write(dedent`
+      TAP version 14
+      ok 1 - a
+      1..1
+    `);
+    const resultBefore = tap.result;
+    tap.writeCoverage(sample, { ok: true });
+    assert(tap.result === resultBefore);               // Same frozen snapshot.
+  });
+});
+
+suite('failure-block synthesis', () => {
+  // The CLI re-iterates leaf failures as a trailing `# Failures:` block on
+  //  finalize — owns the format end-to-end so x-test stays minimal and
+  //  stack-trace URLs can be rewritten to local paths for click-to-open.
+
+  test('a single nested leaf failure renders the breadcrumb + stack', () => {
+    const text = dedent`
+      TAP version 14
+      # Subtest: http://host/page.html
+          # Subtest: group
+              not ok 1 - leaf failed
+                ---
+                message: not ok
+                severity: fail
+                stack: |-
+                  Error: not ok
+                      at fn (http://host/lib.js:10:5)
+                ...
+              1..1
+          not ok 1 - group
+          1..1
+      not ok 1 - http://host/page.html
+      1..1
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: false, ...NOOP_URL_MAP });
+    tap.write(text);
+    const out = stripAnsi(stream.read().toString());
+    // Build the expected trailer explicitly: the blank-separator line is
+    //  `# ` (trailing space) — survives editor trim-trailing-whitespace,
+    //  which a dedent literal would not.
+    const expected = [
+      '# Failures:',
+      '# ',
+      '# http://host/page.html',
+      '# > group',
+      '# > leaf failed',
+      '# Error: not ok',
+      '#     at fn (http://host/lib.js:10:5)',
+      '',
+    ].join('\n');
+    assert(out.endsWith(expected));
+  });
+
+  test('rollup `not ok` (no trailing yaml) is dropped from the block', () => {
+    // `not ok 3 - http://.../page.html` is the URL-level rollup of nested
+    //  failures; its detail already lives in the leaf entry. Dropping it
+    //  prevents duplicate noise. Leaves are identified by a trailing yaml
+    //  diagnostic — rollups don't have one.
+    const text = dedent`
+      TAP version 14
+      # Subtest: http://host/page.html
+          not ok 1 - leaf
+            ---
+            stack: |-
+              Error: leaf
+                  at one (http://host/a.js:1:1)
+            ...
+          1..1
+      not ok 1 - http://host/page.html
+      1..1
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: false, ...NOOP_URL_MAP });
+    tap.write(text);
+    const out = stripAnsi(stream.read().toString());
+    // One failure entry, not two.
+    assert(out.match(/# Failures:/g).length === 1);
+    assert(out.match(/^# Error:/gm).length === 1);
+  });
+
+  test('multiple sibling leaves each get their own entry', () => {
+    const text = dedent`
+      TAP version 14
+      # Subtest: http://host/page.html
+          not ok 1 - first
+            ---
+            stack: |-
+              Error: first
+                  at one (http://host/a.js:1:1)
+            ...
+          not ok 2 - second
+            ---
+            stack: |-
+              Error: second
+                  at two (http://host/b.js:2:2)
+            ...
+          1..2
+      not ok 1 - http://host/page.html
+      1..1
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: false, ...NOOP_URL_MAP });
+    tap.write(text);
+    const out = stripAnsi(stream.read().toString());
+    assert(out.includes('# > first'));
+    assert(out.includes('# > second'));
+    assert(out.match(/^# Error:/gm).length === 2);
+  });
+
+  test('TODO `not ok` does not enter the failures block', () => {
+    const text = dedent`
+      TAP version 14
+      not ok 1 - pending # TODO later
+        ---
+        stack: |-
+          Error: pending
+              at x (http://host/x.js:1:1)
+        ...
+      1..1
+    `;
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: false, ...NOOP_URL_MAP });
+    tap.write(text);
+    const out = stripAnsi(stream.read().toString());
+    assert(!out.includes('# Failures:'));
+  });
+
+  test('passing run (no leaves) emits no failures block', () => {
     const text = dedent`
       TAP version 14
       ok 1 - a
       1..1
     `;
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: false, ...NOOP_URL_MAP });
     tap.write(text);
-    const resultBefore = tap.result;
-    tap.writeCoverage(dedent`
-      # Coverage:
-      #
-      # ok - 100% line coverage goal (got 100%) | ./src/foo.js
-      #
-      # (see ./coverage/lcov.info)
-    `);
-    assert(tap.result === resultBefore);               // Same frozen snapshot.
+    const out = stripAnsi(stream.read().toString());
+    assert(!out.includes('# Failures:'));
   });
-});
 
-suite('failure re-iteration block', () => {
-  test('# Failures: enters the block; all subsequent `#` lines are red', () => {
+  test('rewrite swaps stack frames but NOT the breadcrumb head', () => {
+    // The head is the test page URL (typically served as `index.html` from a
+    //  directory). Rewriting it to a path lands on a directory and the link
+    //  breaks; the original URL is also more useful — it's what a developer
+    //  would open in a browser to repro.
     const text = dedent`
       TAP version 14
-      # Failures:
-      #
-      # http://host/f.html
-      # > initialize
-      # Error: not ok
-      #     at XTestSuite.assert (http://host/x-test-suite.js:112:15)
-    `;
-    const stylized = dedent`
-      ${styles.dim}TAP version 14${styles.reset}
-      ${styles.red}# Failures:${styles.reset}
-      ${styles.red}#${styles.reset}
-      ${styles.red}# http://host/f.html${styles.reset}
-      ${styles.red}# > initialize${styles.reset}
-      ${styles.red}# Error: not ok${styles.reset}
-      ${styles.red}#     at XTestSuite.assert (http://host/x-test-suite.js:112:15)${styles.reset}
+      # Subtest: http://host/page/
+          not ok 1 - leaf
+            ---
+            stack: |-
+              Error: leaf
+                  at fn (http://host/src/lib.js:42:7)
+            ...
+          1..1
+      not ok 1 - http://host/page/
+      1..1
     `;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
+    const tap = new XTestCliTap({
+      stream, color: false,
+      baseUrl:    'http://host/',
+      sourceRoot: '/root/',
+      cwd:        '/root/',
+    });
     tap.write(text);
-    const out = stream.read().toString();
-    assert(out === stylized);
-    assert(stripAnsi(out) === text);
+    const out = stripAnsi(stream.read().toString());
+    const trailer = out.slice(out.indexOf('# Failures:'));
+    assert(trailer.includes('# http://host/page/'));            // Head left alone.
+    assert(trailer.includes('#     at fn (src/lib.js:42:7)'));  // Frame rewritten (bare).
   });
 
-  test('URL and breadcrumb are red only AFTER # Failures:', () => {
+  test('non-matching origins in stack frames pass through verbatim', () => {
     const text = dedent`
       TAP version 14
-      # http://host/somewhere.html
-      # Failures:
-      # http://host/failed.html
-      # > leaf
-    `;
-    const stylized = dedent`
-      ${styles.dim}TAP version 14${styles.reset}
-      ${styles.dim}# http://host/somewhere.html${styles.reset}
-      ${styles.red}# Failures:${styles.reset}
-      ${styles.red}# http://host/failed.html${styles.reset}
-      ${styles.red}# > leaf${styles.reset}
+      # Subtest: http://host/page.html
+          not ok 1 - leaf
+            ---
+            stack: |-
+              Error: leaf
+                  at internal (node:internal/worker:284:11)
+                  at cdn (https://cdn.example.com/vendor.js:1:1)
+            ...
+          1..1
+      not ok 1 - http://host/page.html
+      1..1
     `;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
+    const tap = new XTestCliTap({
+      stream, color: false,
+      baseUrl:    'http://host/',
+      sourceRoot: '/root/',
+      cwd:        '/root/',
+    });
     tap.write(text);
-    const out = stream.read().toString();
-    assert(out === stylized);
-    assert(stripAnsi(out) === text);
+    const out = stripAnsi(stream.read().toString());
+    assert(out.includes('# Failures:'));
+    assert(out.includes('node:internal/worker:284:11'));
+    assert(out.includes('https://cdn.example.com/vendor.js:1:1'));
   });
 
-  test('blank separator inside the block is red', () => {
+  test('depth ≥ 3 builds the full breadcrumb chain', () => {
     const text = dedent`
       TAP version 14
-      # Failures:
-      # http://host/first.html
-      # > leaf
-      #
-      # http://host/second.html
-    `;
-    const stylized = dedent`
-      ${styles.dim}TAP version 14${styles.reset}
-      ${styles.red}# Failures:${styles.reset}
-      ${styles.red}# http://host/first.html${styles.reset}
-      ${styles.red}# > leaf${styles.reset}
-      ${styles.red}#${styles.reset}
-      ${styles.red}# http://host/second.html${styles.reset}
+      # Subtest: http://host/page.html
+          # Subtest: outer
+              # Subtest: inner
+                  not ok 1 - the leaf
+                    ---
+                    stack: |-
+                      Error: leaf
+                          at z (http://host/z.js:1:1)
+                    ...
+                  1..1
+              not ok 1 - inner
+              1..1
+          not ok 1 - outer
+          1..1
+      not ok 1 - http://host/page.html
+      1..1
     `;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
+    const tap = new XTestCliTap({ stream, color: false, ...NOOP_URL_MAP });
     tap.write(text);
-    const out = stream.read().toString();
-    assert(out === stylized);
-    assert(stripAnsi(out) === text);
+    const out = stripAnsi(stream.read().toString());
+    assert(out.includes('# http://host/page.html'));
+    assert(out.includes('# > outer'));
+    assert(out.includes('# > inner'));
+    assert(out.includes('# > the leaf'));
   });
 
-  test('truly empty line inside the block is red', () => {
+  test('synthesis emits red after the terminal plan (does not race finalize)', () => {
+    // The block is written from `#finalize`, which fires on the terminal
+    //  plan line. Confirms the red styling lands and that lines arrive
+    //  AFTER the dim-styled plan.
     const text = dedent`
       TAP version 14
-      # Failures:
-      # http://host/first.html
-
-      # http://host/second.html
-    `;
-    const stylized = dedent`
-      ${styles.dim}TAP version 14${styles.reset}
-      ${styles.red}# Failures:${styles.reset}
-      ${styles.red}# http://host/first.html${styles.reset}
-      ${styles.red}${styles.reset}
-      ${styles.red}# http://host/second.html${styles.reset}
-    `;
-    const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
-    tap.write(text);
-    const out = stream.read().toString();
-    assert(out === stylized);
-    assert(stripAnsi(out) === text);
-  });
-
-  test('a real TAP line inside the block exits failure mode', () => {
-    const text = dedent`
-      TAP version 14
-      # Failures:
-      # http://host/f.html
-      # > leaf
-      ok 1 - a stray test line
-      # ordinary comment
-    `;
-    // Only comments / blanks are sticky-red inside the failure trailer. A
-    //  real assert / plan / bail falls through to the main pattern set,
-    //  clears `inFailureBlock`, and is classified normally — otherwise the
-    //  terminal plan would be swallowed and the stream would hang.
-    const stylized = dedent`
-      ${styles.dim}TAP version 14${styles.reset}
-      ${styles.red}# Failures:${styles.reset}
-      ${styles.red}# http://host/f.html${styles.reset}
-      ${styles.red}# > leaf${styles.reset}
-      ${styles.green}ok 1 - a stray test line${styles.reset}
-      ${styles.dim}# ordinary comment${styles.reset}
+      # Subtest: http://host/page.html
+          not ok 1 - leaf
+            ---
+            stack: |-
+              Error: leaf
+                  at fn (http://host/x.js:1:1)
+            ...
+          1..1
+      not ok 1 - http://host/page.html
+      1..1
     `;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
+    const tap = new XTestCliTap({ stream, color: true, ...NOOP_URL_MAP });
     tap.write(text);
     const out = stream.read().toString();
-    assert(out === stylized);
-    assert(stripAnsi(out) === text);
+    const idxPlan     = out.indexOf('1..1');
+    const idxFailures = out.indexOf(`${styles.red}# Failures:`);
+    assert(idxPlan !== -1 && idxFailures !== -1 && idxPlan < idxFailures);
+    // The synthesized region uses red exclusively (no green/orange/cyan/etc).
+    const synthesized = out.slice(idxFailures);
+    assert(synthesized.includes(styles.red));
+    for (const otherStyle of [styles.green, styles.orange, styles.yellow, styles.cyan, styles.boldRed, styles.dim]) {
+      assert(!synthesized.includes(otherStyle));
+    }
   });
 
-  test('terminal plan after # Failures: fires endStream (regression: hang on failure)', () => {
-    // Regression: `# Failures:` used to switch the parser to a pattern set
-    //  with a catch-all sentinel, so the trailing `1..N` was consumed as
-    //  failure commentary and `endStream` never fired — the CLI would hang
-    //  to the global timeout on any test run that had failures.
+  test('endStream fires exactly once even when failures synthesize', () => {
     let ended = 0;
     const tap = new XTestCliTap({
       stream: new PassThrough(),
       color:  false,
       endStream: () => { ended++; },
+      ...NOOP_URL_MAP,
     });
     tap.write(dedent`
       TAP version 14
-      not ok 1 - broken
-      # Failures:
-      # http://host/f.html
-      # > leaf
+      not ok 1 - leaf
+        ---
+        stack: |-
+          Error: leaf
+              at fn (http://host/x.js:1:1)
+        ...
       1..1
     `);
     assert(ended === 1);
-    assert(tap.result.ok === false);
-    assert(tap.result.testNotOk === 1);
-    assert(tap.result.planEnd === 1);
-  });
-
-  test('terminal Bail out! after # Failures: fires endStream', () => {
-    let ended = 0;
-    const tap = new XTestCliTap({
-      stream: new PassThrough(),
-      color:  false,
-      endStream: () => { ended++; },
-    });
-    tap.write(dedent`
-      TAP version 14
-      # Failures:
-      # http://host/f.html
-      Bail out! cannot continue
-    `);
-    assert(ended === 1);
-    assert(tap.result.bailed === true);
-  });
-
-  test('summary `#` lines BEFORE the block stay dim', () => {
-    const text = dedent`
-      TAP version 14
-      # tests 101
-      # pass 91
-      # fail 1
-      # Failures:
-    `;
-    const stylized = dedent`
-      ${styles.dim}TAP version 14${styles.reset}
-      ${styles.dim}# tests 101${styles.reset}
-      ${styles.dim}# pass 91${styles.reset}
-      ${styles.dim}# fail 1${styles.reset}
-      ${styles.red}# Failures:${styles.reset}
-    `;
-    const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
-    tap.write(text);
-    const out = stream.read().toString();
-    assert(out === stylized);
-    assert(stripAnsi(out) === text);
   });
 });
 
@@ -892,7 +931,7 @@ suite('edge cases', () => {
       ok 1 - real test
       1..1
     `;
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write(text);
     assert.deepEqual(tap.result, {
       ok: true,
@@ -911,7 +950,7 @@ suite('edge cases', () => {
 
   test('handles \\r\\n (Windows) line endings', () => {
     const text = 'TAP version 14\r\nok 1 - hi\r\n1..1\r\n';
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write(text);
     assert.deepEqual(tap.result, {
       ok: true,
@@ -935,7 +974,7 @@ suite('edge cases', () => {
       NOT OK 1
       1..0
     `;
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write(text);
     assert.deepEqual(tap.result, {
       ok: true,
@@ -958,7 +997,7 @@ suite('edge cases', () => {
       okay then
       1..0
     `;
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write(text);
     assert.deepEqual(tap.result, {
       ok: true,
@@ -990,7 +1029,7 @@ suite('write() handles multi-line blobs (browser-bridge path)', () => {
       1..1
     `;
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: true });
+    const tap = new XTestCliTap({ stream, color: true, ...NOOP_URL_MAP });
     assert.doesNotThrow(() => tap.write(blob));
     assert(stream.read().toString().length > 0);
     assert(tap.result.testNotOk === 1);
@@ -1007,11 +1046,11 @@ suite('write() handles multi-line blobs (browser-bridge path)', () => {
     `;
 
     const streamA = new PassThrough();
-    const tapA = new XTestCliTap({ stream: streamA, color: false });
+    const tapA = new XTestCliTap({ stream: streamA, color: false, ...NOOP_URL_MAP });
     tapA.write(text);
 
     const streamB = new PassThrough();
-    const tapB = new XTestCliTap({ stream: streamB, color: false });
+    const tapB = new XTestCliTap({ stream: streamB, color: false, ...NOOP_URL_MAP });
     for (const line of text.split('\n')) {
       tapB.write(line);
     }
@@ -1022,12 +1061,12 @@ suite('write() handles multi-line blobs (browser-bridge path)', () => {
 
 suite('lifecycle guards', () => {
   test('.result before the stream terminates throws', () => {
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     assert.throws(() => tap.result, /result accessed before end/);
   });
 
   test('.result after the stream terminates returns the frozen result', () => {
-    const tap = new XTestCliTap({ stream: new PassThrough(), color: false });
+    const tap = new XTestCliTap({ stream: new PassThrough(), color: false, ...NOOP_URL_MAP });
     tap.write('TAP version 14\n1..0');
     assert.doesNotThrow(() => tap.result);
     // Repeated reads return the same object.
@@ -1036,7 +1075,7 @@ suite('lifecycle guards', () => {
 
   test('write() after the stream terminates passes the line through raw', () => {
     const stream = new PassThrough();
-    const tap = new XTestCliTap({ stream, color: false });
+    const tap = new XTestCliTap({ stream, color: false, ...NOOP_URL_MAP });
     tap.write('TAP version 14\nok 1 - a\n1..1');        // Plan terminates.
     const frozen = tap.result;
     tap.write('# trailing diagnostic\n');              // Post-end write.
@@ -1053,6 +1092,7 @@ suite('auto-end', () => {
       stream: new PassThrough(),
       color:  false,
       endStream: () => { ended++; },
+      ...NOOP_URL_MAP,
     });
     tap.write('TAP version 14\nok 1 - a\nok 2 - b\n1..2');
     assert(ended === 1);
@@ -1066,6 +1106,7 @@ suite('auto-end', () => {
       stream: new PassThrough(),
       color:  false,
       endStream: () => { ended++; },
+      ...NOOP_URL_MAP,
     });
     tap.write('TAP version 14\nBail out! launch timeout');
     assert(ended === 1);
@@ -1082,6 +1123,7 @@ suite('auto-end', () => {
       stream: new PassThrough(),
       color:  false,
       endStream: () => { ended++; },
+      ...NOOP_URL_MAP,
     });
     tap.write('TAP version 14\n1..0');
     assert(ended === 1);
@@ -1095,6 +1137,7 @@ suite('auto-end', () => {
       stream: new PassThrough(),
       color:  false,
       endStream: () => { ended++; },
+      ...NOOP_URL_MAP,
     });
     tap.write('TAP version 14\nok 1 - a\n1..1');        // Auto-ends on plan line.
     tap.write('ok 2 - surprise');                      // Post-end, not counted.

--- a/x-test-cli-coverage.js
+++ b/x-test-cli-coverage.js
@@ -190,7 +190,7 @@ export class XTestCliCoverage {
    * Status token is native TAP vocabulary — `ok` / `not ok` — so readers
    * who scan TAP already know what it means.
    */
-  static formatCoverageBlock({ result, lcovPath }) {
+  static formatCoverageBlock({ result }) {
     // Columns we pad to max width across all rows:
     //   status   — “ok” or “not ok”                 (max width: 6)
     //   goal     — “65%” or “100%”                  (max width: 4)
@@ -212,8 +212,6 @@ export class XTestCliCoverage {
       '# Coverage:',
       '#',
       ...rows,
-      '#',
-      `# (see ${lcovPath})`,
     ].join('\n');
   }
 

--- a/x-test-cli-tap.js
+++ b/x-test-cli-tap.js
@@ -2,48 +2,34 @@
  * Single authority for TAP interpretation, result accumulation, and rendering.
  */
 export class XTestCliTap {
-  // Whole-line TAP patterns, iterated in declaration order.
+  // Whole-line TAP patterns, iterated in declaration order. `subtest` and
+  //  `testNotOk` carry named captures (name / description) that failure
+  //  synthesis reads from the dispatch match — same precedent as `plan`
+  //  and `bail` already use for their groups.
   static #patterns = {
     yamlOpen:       /^\s*---\s*$/,
     bail:           /^\s*Bail out!(?:\s+(?<reason>.*?))?\s*$/,
-    subtest:        /^\s*# Subtest:.*$/,
-    failuresHeader: /^\s*# Failures:\s*$/,
+    subtest:        /^\s*# Subtest:\s*(?<name>.*?)\s*$/,
     version:        /^\s*TAP [Vv]ersion\b.*$/,
     plan:           /^\s*(?<start>\d+)\.\.(?<end>\d+)(?:\s+#.*)?$/,
     testSkip:       /^\s*ok\b.*#\s*SKIP\b.*$/,
     testTodoOk:     /^\s*ok\b.*#\s*TODO\b.*$/,
     testTodoNotOk:  /^\s*not ok\b.*#\s*TODO\b.*$/,
     testOk:         /^\s*ok\b.*$/,
-    testNotOk:      /^\s*not ok\b.*$/,
+    testNotOk:      /^\s*not ok\b(?:\s+\d+)?\s*(?:-\s*)?(?<description>.*?)\s*$/,
     comment:        /^\s*#.*$/,
     blank:          /^\s*$/,
     unknown:        /^/,
   };
 
-  // Coverage-block patterns, used only by `writeCoverage`. The CLI writes its
-  //  coverage diagnostic through a dedicated path so the styling applies
-  //  regardless of whether the TAP stream has already ended.
-  static #coveragePatterns = {
-    coverageHeader:   /^\s*# Coverage:\s*$/,
-    coverageRowOk:    /^\s*#\s+ok\s+-\s+\d+%\s+line coverage goal\b.*\|.*$/,
-    coverageRowNotOk: /^\s*#\s+not ok\s+-\s+\d+%\s+line coverage goal\b.*\|.*$/,
-    coverageReport:   /^\s*#\s+\(see\b.*\)\s*$/,
-    coverageBlank:    /^\s*#\s*$/,
-  };
-
   // YAML-specific, whole-line TAP patterns, iterated in declaration order.
+  //  `yamlStackKey` matches the `stack: |-` block-scalar header inside a
+  //  diagnostic; capture is the key's indent (synthesis uses it as the
+  //  strip column for the lines beneath).
   static #inYamlPatterns = {
-    yamlClose:   /^\s*\.\.\.\s*$/,
-    yamlUnknown: new RegExp(XTestCliTap.#patterns.unknown.source),
-  };
-
-  // Failure-specific, whole-line TAP patterns, iterated in declaration order.
-  //  No catch-all sentinel: anything that isn’t a comment or blank falls
-  //  through to the main pattern set so a trailing plan / assert / bail still
-  //  terminates the stream and clears `inFailureBlock`.
-  static #inFailurePatterns = {
-    failureComment: new RegExp(XTestCliTap.#patterns.comment.source),
-    failureBlank:   new RegExp(XTestCliTap.#patterns.blank.source),
+    yamlClose:    /^\s*\.\.\.\s*$/,
+    yamlStackKey: /^(?<indent>\s*)stack:\s*\|-?\s*$/,
+    yamlUnknown:  new RegExp(XTestCliTap.#patterns.unknown.source),
   };
 
   // Named ANSI styles to colorize / stylize stdout text.
@@ -61,10 +47,18 @@ export class XTestCliTap {
   #stream;
   #color;
   #endStream;
+  // All three carry a trailing `/` — caller's contract. `#rewriteUrl` chains
+  //  substring substitutions and a missing slash would corrupt the output.
+  #baseUrl;                             // URL prefix — paired with `#sourceRoot` to project stack-line URLs to disk paths
+  #sourceRoot;                          // absolute fs path — the disk projection of `#baseUrl`
+  #cwd;                                 // absolute fs path — output paths render relative to this
+  #parents          = [];               // currently-active subtest names: pushed on `# Subtest:`, popped on the inner `1..N` plan that closes it
+  #failures         = [];               // accumulated `{ breadcrumb, stackLines }` — drained by `#finalize`
+  #pendingFailure   = null;             // set on a leaf `not ok`; promoted to `#failures` on yamlClose iff we collected stack lines
+  #stackIndent      = null;             // strip column for stack lines, set when `yamlStackKey` fires inside a pendingFailure's yaml
   #state = {
     started:        false, // flipped true on `TAP version N`; gates all parsing
     inYaml:         false, // classification mode flag — inside a `---`/`...` block
-    inFailureBlock: false, // classification mode flag — inside `# Failures:` trailer
     ended:          false, // set by terminal TAP line; gates write/result
     result:         null,  // frozen snapshot produced at end-of-stream
     planStart:      null,  // lower bound of the `N..M` plan (null = no plan seen)
@@ -78,10 +72,13 @@ export class XTestCliTap {
     bailReason:     null,  // free text after `Bail out!`, if any
   };
 
-  constructor({ stream, color, endStream }) {
-    this.#stream    = stream;
-    this.#color     = color;
-    this.#endStream = endStream;
+  constructor({ stream, color, endStream, baseUrl, sourceRoot, cwd }) {
+    this.#stream     = stream;
+    this.#color      = color;
+    this.#endStream  = endStream;
+    this.#baseUrl    = baseUrl;
+    this.#sourceRoot = sourceRoot;
+    this.#cwd        = cwd;
   }
 
   /**
@@ -107,30 +104,20 @@ export class XTestCliTap {
   }
 
   /**
-   * Render a CLI-produced `# Coverage:` diagnostic block. Styles header /
-   * report / row lines regardless of whether the TAP stream has already ended —
-   * the coverage block lands *after* the plan line by construction (driver
-   * returns, CLI grades, CLI writes), so routing it through `write()` would put
-   * it on the post-end raw-passthrough path.
+   * Render a CLI-produced `# Coverage:` diagnostic block. Styles every line
+   * uniformly — `red` when any goal failed, `dim` otherwise. The caller
+   * gates this entirely on test-pass: when tests fail, coverage is skipped
+   * (don't muddy a failing run with secondary signals). Routing this
+   * through `write()` would put it on the post-end raw-passthrough path,
+   * hence the dedicated entry point.
    */
-  writeCoverage(block) {
+  writeCoverage(block, { ok }) {
+    const style = ok ? XTestCliTap.#styles.dim : XTestCliTap.#styles.red;
     const lines = block.split(/\r?\n/);
     if (lines.length > 0 && lines[lines.length - 1] === '') {
       lines.pop();
     }
     for (const line of lines) {
-      let style;
-      if (XTestCliTap.#coveragePatterns.coverageRowOk.test(line)) {
-        style = XTestCliTap.#styles.green;
-      } else if (XTestCliTap.#coveragePatterns.coverageRowNotOk.test(line)) {
-        style = XTestCliTap.#styles.red;
-      } else if (XTestCliTap.#coveragePatterns.coverageHeader.test(line)) {
-        style = XTestCliTap.#styles.dim;
-      } else if (XTestCliTap.#coveragePatterns.coverageReport.test(line)) {
-        style = XTestCliTap.#styles.dim;
-      } else if (XTestCliTap.#coveragePatterns.coverageBlank.test(line)) {
-        style = XTestCliTap.#styles.dim;
-      }
       this.#emit(line, style);
     }
   }
@@ -175,9 +162,54 @@ export class XTestCliTap {
       testOk, testNotOk, testSkip, testTodoOk, testTodoNotOk, testCount,
       planStart, planEnd, bailed, bailReason,
     };
+    this.#emitFailureBlock();
     if (this.#endStream) {
       this.#endStream();
     }
+  }
+
+  /**
+   * Render the trailing `# Failures:` summary from accumulated leaf failures.
+   * Owned by the CLI (not the in-browser test runner) so we can rewrite stack
+   * URLs to local paths, keep x-test minimal, and avoid a fragile contract
+   * where two layers must agree on the format.
+   */
+  #emitFailureBlock() {
+    if (this.#failures.length === 0) {
+      return;
+    }
+    this.#emit('# Failures:', XTestCliTap.#styles.red);
+    for (const failure of this.#failures) {
+      this.#emit('# ', XTestCliTap.#styles.red);
+      const [url, ...descriptions] = failure.breadcrumb;
+      // Leave the top url form intact. Rewriting it to a path lands on a
+      //  directory (the URL is typically served as `index.html`), and the
+      //  original URL is the actual link a developer would open to repro the
+      //  failure in a browser.
+      this.#emit(`# ${url}`, XTestCliTap.#styles.red);
+      for (const description of descriptions) {
+        this.#emit(`# > ${description}`, XTestCliTap.#styles.red);
+      }
+      for (const line of failure.stackLines) {
+        this.#emit(line === '' ? '#' : `# ${line}`, XTestCliTap.#styles.red);
+      }
+    }
+  }
+
+  /**
+   * Two-step substring rewrite:
+   *   1. `<baseUrl>` → `<sourceRoot>/` projects the served URL into its on-
+   *      disk location (both fully-qualified, so the swap is honest).
+   *   2. `<cwd>/`     → `''`            strips the cwd prefix so output is
+   *      bare cwd-relative (`x-test-cli-tap.js:200:5`).
+   * Each step no-ops when its substring isn't present — frames from another
+   * host or node:internal URLs pass through verbatim. Splitting steps lets
+   * `sourceRoot` and `cwd` differ (e.g. `root: './public'` puts sourceRoot
+   * one level below cwd, and output renders `public/foo.js` rather than
+   * losing the `public/` prefix).
+   */
+  #rewriteUrl(text) {
+    return text.split(this.#baseUrl).join(this.#sourceRoot).split(this.#cwd).join('');
   }
 
   /**
@@ -193,27 +225,19 @@ export class XTestCliTap {
 
   /**
    * Find the pattern that classifies `line`. State picks which set to
-   * iterate; each set ends in a catch-all sentinel (`unknown`, `yamlUnknown`,
-   * `failureUnknown`) so a hit is guaranteed.
+   * iterate; each set ends in a catch-all sentinel (`unknown`, `yamlUnknown`)
+   * so a hit is guaranteed.
    */
   #tryPatterns(line) {
-    // In yaml mode the set is exhaustive (ends in a catch-all). In failure
-    //  mode we only match comments/blanks so that a trailing plan / assert /
-    //  bail falls through to the main set and still terminates the stream.
-    const sets = this.#state.inYaml
-      ? [XTestCliTap.#inYamlPatterns]
-      : this.#state.inFailureBlock
-        ? [XTestCliTap.#inFailurePatterns, XTestCliTap.#patterns]
-        : [XTestCliTap.#patterns];
-    for (const patterns of sets) {
-      for (const pattern of Object.values(patterns)) {
-        const match = pattern.exec(line);
-        if (match) {
-          return { pattern, match };
-        }
+    // Yaml mode picks the yaml set, otherwise the main set. Both end in a
+    //  catch-all sentinel (`/^/`) so a hit is guaranteed.
+    const patterns = this.#state.inYaml ? XTestCliTap.#inYamlPatterns : XTestCliTap.#patterns;
+    for (const pattern of Object.values(patterns)) {
+      const match = pattern.exec(line);
+      if (match) {
+        return { pattern, match };
       }
     }
-    throw new Error('Invariant violated: every pattern set must end in a catch-all sentinel.');
   }
 
   /**
@@ -249,66 +273,83 @@ export class XTestCliTap {
         style = XTestCliTap.#styles.dim;
         break;
       case XTestCliTap.#patterns.subtest:
+        // Push entering the subtest; the matching inner `1..N` plan pops.
+        this.#parents.push(match.groups.name);
+        this.#pendingFailure = null;                    // rollups never trail a subtest header
         style = XTestCliTap.#styles.cyan;
         break;
       case XTestCliTap.#patterns.testSkip:
-        this.#state.inFailureBlock = false;
         if (atTopLevel) {
           this.#state.testSkip++;
         }
         style = XTestCliTap.#styles.orange;
         break;
       case XTestCliTap.#patterns.testTodoOk:
-        this.#state.inFailureBlock = false;
         if (atTopLevel) {
           this.#state.testTodoOk++;
         }
         style = XTestCliTap.#styles.yellow; // TODO that passed! Style yellow.
         break;
       case XTestCliTap.#patterns.testTodoNotOk:
-        this.#state.inFailureBlock = false;
         if (atTopLevel) {
           this.#state.testTodoNotOk++;
         }
         style = XTestCliTap.#styles.orange;
         break;
       case XTestCliTap.#patterns.testOk:
-        this.#state.inFailureBlock = false;
         if (atTopLevel) {
           this.#state.testOk++;
         }
         style = XTestCliTap.#styles.green;
         break;
-      case XTestCliTap.#patterns.testNotOk:
-        this.#state.inFailureBlock = false;
+      case XTestCliTap.#patterns.testNotOk: {
         if (atTopLevel) {
           this.#state.testNotOk++;
         }
+        // Stash a candidate failure. Promoted to `#failures` only if a yaml
+        //  block follows AND its `stack: |-` collects lines — that's how we
+        //  distinguish a leaf from a subtest rollup like
+        //  `not ok 3 - http://.../test-suite.html`.
+        const description = match.groups.description.trim();
+        const breadcrumb = [...this.#parents, description];
+        const stackLines = [];
+        this.#pendingFailure = { breadcrumb, stackLines };
         style = XTestCliTap.#styles.red;
         break;
+      }
       case XTestCliTap.#patterns.yamlOpen:
         this.#state.inYaml = true;
         style = XTestCliTap.#styles.dim;
         break;
       case XTestCliTap.#inYamlPatterns.yamlClose:
         this.#state.inYaml = false;
+        if (this.#pendingFailure) {
+          this.#failures.push(this.#pendingFailure);
+        }
+        this.#pendingFailure   = null;
+        this.#stackIndent = null;
+        style = XTestCliTap.#styles.dim;
+        break;
+      case XTestCliTap.#inYamlPatterns.yamlStackKey:
+        if (this.#pendingFailure) {
+          // The block-scalar header sits at `<keyIndent>stack: |-`; lines
+          //  beneath are indented by keyIndent + 2 (yaml convention).
+          this.#stackIndent = match.groups.indent.length + 2;
+        }
         style = XTestCliTap.#styles.dim;
         break;
       case XTestCliTap.#inYamlPatterns.yamlUnknown:
         // In-yaml body — dim the whole line regardless of its content.
+        //  When we're inside the active stack block, also collect each line
+        //  (stripped + URL-rewritten) into the pending failure's stackLines.
+        if (this.#pendingFailure && this.#stackIndent !== null) {
+          if (line.trim() === '') {
+            this.#pendingFailure.stackLines.push('');
+          } else if (line.length >= this.#stackIndent) {
+            this.#pendingFailure.stackLines.push(this.#rewriteUrl(line.slice(this.#stackIndent)));
+          }
+        }
         style = XTestCliTap.#styles.dim;
-        break;
-      case XTestCliTap.#patterns.failuresHeader:
-        // Sticky: once the trailing failure re-iteration block starts,
-        //  subsequent comments/blanks stay red until an assert fires.
-        this.#state.inFailureBlock = true;
-        style = XTestCliTap.#styles.red;
-        break;
-      case XTestCliTap.#inFailurePatterns.failureComment:
-        style = XTestCliTap.#styles.red;
-        break;
-      case XTestCliTap.#inFailurePatterns.failureBlank:
-        style = XTestCliTap.#styles.red;
         break;
       case XTestCliTap.#patterns.comment:
         style = XTestCliTap.#styles.dim;
@@ -318,6 +359,11 @@ export class XTestCliTap {
           this.#state.planStart = Number(match.groups.start);
           this.#state.planEnd   = Number(match.groups.end);
           this.#state.ended     = true; // Top-level plan is terminal.
+        } else {
+          // Inner plan closes the most recently opened subtest. Pairs with
+          //  the `push` in the subtest arm so the stack always reflects
+          //  currently-active subtests.
+          this.#parents.pop();
         }
         style = XTestCliTap.#styles.dim;
         break;

--- a/x-test-cli.js
+++ b/x-test-cli.js
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 
 import { readFileSync } from 'node:fs';
-import { relative, resolve } from 'node:path';
+import { resolve } from 'node:path';
 
 import { XTestCliBrowserPuppeteer, XTestCliBrowserPlaywright } from './x-test-cli-browser.js';
 import { XTestCliTap } from './x-test-cli-tap.js';
 import { XTestCliConfig } from './x-test-cli-config.js';
 import { XTestCliCoverage } from './x-test-cli-coverage.js';
+
+const cwd = process.cwd();
 
 const SUPPORTED_CLIENTS = ['puppeteer', 'playwright'];
 const SUPPORTED_REPORTERS = ['tap', 'auto'];
@@ -182,7 +184,7 @@ for (const arg of args) {
 //  flags override config values via the spread order below.
 let configOptions;
 try {
-  configOptions = await XTestCliConfig.load(process.cwd());
+  configOptions = await XTestCliConfig.load(cwd);
 } catch (error) {
   fail(`Error: failed to load x-test.config.js: ${error.message}`);
 }
@@ -210,14 +212,19 @@ if (options.coverage === true || options.coverage === 'true') {
   fail(`Error: --coverage must be "true" or "false", got "${options.coverage}".`);
 }
 
-// The `root` argument is validated unconditionally — bare/absolute paths are
-//  config-shape errors regardless of whether coverage is on. The 
-//  `coverageGoals` config only matters with coverage, so it stays gated.
+// The `root` argument is validated unconditionally — bare / absolute paths are
+//  config-shape errors regardless of coverage flag. The `coverageGoals` config
+//  only matters with coverage, so it stays gated.
 try {
   XTestCliConfig.validateRoot(options.root);
 } catch (error) {
   fail(`Error: ${error.message}`, 2);
 }
+
+// Declare fully-qualified base url and source root for output mappings. All
+//  three carry trailing `/` per `XTestCliTap`'s constructor contract.
+const baseUrl    = new URL(options.url).origin + '/';
+const sourceRoot = resolve(cwd, options.root ?? '.') + '/';
 
 // Coverage requires goals. Without `coverageGoals` there is nothing to
 //  grade against — treat as an invocation error so misconfiguration fails
@@ -273,7 +280,7 @@ const color         = !suppressColor && !!forceColor;
 //  satisfied, or `Bail out!`); we bridge that to the driver via `streamEnded`,
 //  so the driver knows when to stop collecting coverage and close the browser.
 const { promise: streamEnded, resolve: endStream } = Promise.withResolvers();
-const tap = new XTestCliTap({ stream: process.stdout, color, endStream });
+const tap = new XTestCliTap({ stream: process.stdout, color, endStream, baseUrl, sourceRoot, cwd: cwd + '/' });
 
 // Resolve the target URL. Apply the name-pattern filter if present.
 let url = options.url;
@@ -334,18 +341,13 @@ try {
 //  stream so the block lands inside the captured TAP output. x-test’s own
 //  in-browser coverage diagnostic still prints in parallel this increment; a
 //  later increment removes that path.
+// Skip coverage entirely when tests failed — the run is already not-ok and
+//  layering coverage on top is noise. Coverage is a secondary signal that
+//  only matters once the primary one (test pass/fail) is green.
 let coverageOk = true;
-if (coverage && rawCoverageEntries) {
+if (coverage && rawCoverageEntries && tap.result.ok) {
   try {
     const origin = new URL(url).origin;
-    // The `root` (config) is the disk directory the dev server serves as its
-    //  root — the directory goal paths resolve against. Defaults to cwd.
-    //  Set this when the server root isn’t cwd (e.g. serving `./src` or
-    //  `./dist`), otherwise synthesis-from-disk and lcov `SF:` will point at
-    //  the wrong files.
-    const sourceRoot = options.root
-      ? resolve(process.cwd(), options.root)
-      : process.cwd();
     // Synthesize entries for goal files the browser never loaded but that
     //  exist on disk — so the summary shows `0.0 / goal  not ok` with a real
     //  denominator and lcov shows the file all-red, rather than a terse
@@ -357,7 +359,7 @@ if (coverage && rawCoverageEntries) {
       goals:   options.coverageGoals,
     });
     const allEntries = [...rawCoverageEntries, ...synthetic];
-    const lcovAbsolute = await XTestCliCoverage.writeLcov({
+    await XTestCliCoverage.writeLcov({
       entries: allEntries,
       outDir:  './coverage',
       origin,                          // In-origin entries map to on-disk paths.
@@ -370,7 +372,7 @@ if (coverage && rawCoverageEntries) {
       goals:   options.coverageGoals,
     });
     coverageOk = graded.ok;
-    tap.writeCoverage(XTestCliCoverage.formatCoverageBlock({ result: graded, lcovPath: displayPath(lcovAbsolute) }));
+    tap.writeCoverage(XTestCliCoverage.formatCoverageBlock({ result: graded }), { ok: graded.ok });
   } catch (error) {
     tap.write('Bail out! Coverage processing failed.');
     console.error(error); // eslint-disable-line no-console
@@ -380,15 +382,4 @@ if (coverage && rawCoverageEntries) {
 
 if (!tap.result.ok || !coverageOk) {
   process.exit(1);
-}
-
-// Render absolute paths that live under cwd as `./rel/path`; fall back to
-//  the absolute form when the target escapes cwd (so users always see a
-//  path they can open from wherever they invoked the CLI).
-function displayPath(absolute) {
-  const rel = relative(process.cwd(), absolute);
-  if (rel === '' || rel.startsWith('..')) {
-    return absolute;
-  }
-  return './' + rel;
 }


### PR DESCRIPTION
By having the CLI emit the summary failures, we gain the following:

- Reduction of logic in pure “x-test” browser code.
- Output of “x-test” stream is as minimal as possible.
- CLI can map URLs to file paths (browser cannot know this).

This last point is critical. Modern terminals will allow you to click on text that “looks like a local file” and open it directly. This is good for both humans and AI agents.

```sh
# http://127.0.0.1:8080/test/browser/index.html
# > lcov writer
# > writes one record per targeted file
# Error: not ok
#     at writeLcov (x-test-cli-coverage.js:120:9)
#     at x-test-cli.js:343:33
#     at MessagePort.<anonymous> (node:internal/worker:284:11)
#     at fetch (https://cdn.example.com/vendor/lib.js:42:9)
```