### PR TITLE
Update where coverage is formatted / handled.

### DIFF
--- a/test/node/coverage.test.js
+++ b/test/node/coverage.test.js
@@ -135,10 +135,10 @@ suite('XTestCliCoverage.gradeCoverage', () => {
       goals:   { './src/a.js': { lines: 100 } },
     });
     assert(result.ok === true);
-    assert(result.rows.length === 1);
-    assert(result.rows[0].lines.met === true);
-    assert(result.rows[0].lines.percent === 100);
-    assert(result.rows[0].lines.missing === false);
+    assert(result.results.length === 1);
+    assert(result.results[0].lines.met === true);
+    assert(result.results[0].lines.percent === 100);
+    assert(result.results[0].lines.missing === false);
   });
 
   test('goal above percent → not met, overall not ok', () => {
@@ -151,8 +151,8 @@ suite('XTestCliCoverage.gradeCoverage', () => {
       goals:   { './src/a.js': { lines: 100 } },
     });
     assert(result.ok === false);
-    assert(result.rows[0].lines.met === false);
-    assert(result.rows[0].lines.percent === 50);
+    assert(result.results[0].lines.met === false);
+    assert(result.results[0].lines.percent === 50);
   });
 
   test('missing goal file → row flagged missing, not met', () => {
@@ -162,9 +162,9 @@ suite('XTestCliCoverage.gradeCoverage', () => {
       goals:   { './src/missing.js': { lines: 80 } },
     });
     assert(result.ok === false);
-    assert(result.rows[0].lines.missing === true);
-    assert(result.rows[0].lines.met === false);
-    assert(result.rows[0].lines.goal === 80);
+    assert(result.results[0].lines.missing === true);
+    assert(result.results[0].lines.met === false);
+    assert(result.results[0].lines.goal === 80);
   });
 
   test('percent uses two-decimal rounding', () => {
@@ -176,59 +176,8 @@ suite('XTestCliCoverage.gradeCoverage', () => {
       origin,
       goals:   { './src/a.js': { lines: 30 } },
     });
-    assert(result.rows[0].lines.percent === 33.33);
-    assert(result.rows[0].lines.met === true);
-  });
-});
-
-suite('XTestCliCoverage.formatCoverageBlock', () => {
-  test('full shape: header, blank, rows', () => {
-    const result = {
-      ok: false,
-      rows: [
-        { path: './src/reporter.js', lines: { covered:  60, total:  99, percent: 60.61, goal: 65,  met: false, missing: false } },
-        { path: './src/x-test.js',   lines: { covered: 100, total: 100, percent: 100,   goal: 100, met: true,  missing: false } },
-      ],
-    };
-    const expected = dedent`
-      # Coverage:
-      #
-      # not ok - 65%  line coverage goal (got 60.61%) | ./src/reporter.js
-      # ok     - 100% line coverage goal (got 100%)   | ./src/x-test.js`;
-    assert(XTestCliCoverage.formatCoverageBlock({ result }) === expected);
-  });
-
-  test('missing row uses "(missing)" where (got N%) would go', () => {
-    const result = {
-      ok: false,
-      rows: [
-        { path: './src/missing.js', lines: { covered: 0, total: 0, percent: 0, goal: 80, met: false, missing: true } },
-      ],
-    };
-    const expected = dedent`
-      # Coverage:
-      #
-      # not ok - 80% line coverage goal (missing) | ./src/missing.js`;
-    assert(XTestCliCoverage.formatCoverageBlock({ result }) === expected);
-  });
-
-  test('percent trims trailing zeros but keeps two-decimal precision', () => {
-    const result = {
-      ok: true,
-      rows: [
-        // 60.6000 → "60.6"; 60.6333 → "60.63"; 100.00 → "100"
-        { path: 'a', lines: { covered: 1, total: 1, percent: 60.6,  goal:  50, met: true, missing: false } },
-        { path: 'b', lines: { covered: 1, total: 1, percent: 60.63, goal:  50, met: true, missing: false } },
-        { path: 'c', lines: { covered: 1, total: 1, percent: 100,   goal: 100, met: true, missing: false } },
-      ],
-    };
-    const expected = dedent`
-      # Coverage:
-      #
-      # ok - 50%  line coverage goal (got 60.6%)  | a
-      # ok - 50%  line coverage goal (got 60.63%) | b
-      # ok - 100% line coverage goal (got 100%)   | c`;
-    assert(XTestCliCoverage.formatCoverageBlock({ result }) === expected);
+    assert(result.results[0].lines.percent === 33.33);
+    assert(result.results[0].lines.met === true);
   });
 });
 
@@ -296,11 +245,11 @@ suite('XTestCliCoverage.synthesizeMissingEntries', () => {
       goals:   { './src/onDisk.js': { lines: 80 } },
     });
     assert(graded.ok === false);
-    assert(graded.rows[0].lines.missing === false);
-    assert(graded.rows[0].lines.covered === 0);
-    assert(graded.rows[0].lines.total === 2);
-    assert(graded.rows[0].lines.percent === 0);
-    assert(graded.rows[0].lines.met === false);
+    assert(graded.results[0].lines.missing === false);
+    assert(graded.results[0].lines.covered === 0);
+    assert(graded.results[0].lines.total === 2);
+    assert(graded.results[0].lines.percent === 0);
+    assert(graded.results[0].lines.met === false);
   });
 });
 

--- a/test/node/tap.test.js
+++ b/test/node/tap.test.js
@@ -594,41 +594,78 @@ suite('colorization', () => {
 });
 
 suite('coverage summary', () => {
-  const sample = dedent`
+  // Mirrors `XTestCliCoverage.gradeCoverage`'s `rows` shape — TAP synthesizes
+  //  the comment block from these directly. The block-level styling (`ok`
+  //  vs `red`) is derived from `rows.every(r => r.lines.met)`, so a row's
+  //  `met` flag drives the visual outcome.
+  const passingRow = { path: './src/foo.js', lines: { covered: 100, total: 100, percent: 100,   goal: 100, met: true,  missing: false } };
+  const failingRow = { path: './src/bar.js', lines: { covered:  60, total:  99, percent: 60.64, goal:  65, met: false, missing: false } };
+  const mixedExpected = dedent`
     # Coverage:
     #
     # ok     - 100% line coverage goal (got 100%)   | ./src/foo.js
     # not ok - 65%  line coverage goal (got 60.64%) | ./src/bar.js
   `;
 
-  test('ok=true → every line dim', () => {
+  test('full shape: header, blank, padded rows', () => {
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: false, ...NOOP_URL_MAP });
+    tap.writeCoverage([passingRow, failingRow]);
+    const out = stream.read().toString();
+    assert(out === mixedExpected);
+  });
+
+  test('all rows met → every line dim', () => {
     const stream = new PassThrough();
     const tap = new XTestCliTap({ stream, color: true, ...NOOP_URL_MAP });
-    tap.writeCoverage(sample, { ok: true });
+    tap.writeCoverage([passingRow]);
     const out = stream.read().toString();
     for (const line of out.split('\n').filter(l => l.length > 0)) {
       assert(line.startsWith(styles.dim));
     }
-    assert(stripAnsi(out) === sample);
   });
 
-  test('ok=false → every line red', () => {
+  test('any row unmet → every line red', () => {
     const stream = new PassThrough();
     const tap = new XTestCliTap({ stream, color: true, ...NOOP_URL_MAP });
-    tap.writeCoverage(sample, { ok: false });
+    tap.writeCoverage([passingRow, failingRow]);
     const out = stream.read().toString();
     for (const line of out.split('\n').filter(l => l.length > 0)) {
       assert(line.startsWith(styles.red));
     }
-    assert(stripAnsi(out) === sample);
   });
 
-  test('coverage block renders raw when color is off', () => {
+  test('missing row uses "(missing)" where (got N%) would go', () => {
     const stream = new PassThrough();
     const tap = new XTestCliTap({ stream, color: false, ...NOOP_URL_MAP });
-    tap.writeCoverage(sample, { ok: true });
+    tap.writeCoverage([
+      { path: './src/missing.js', lines: { covered: 0, total: 0, percent: 0, goal: 80, met: false, missing: true } },
+    ]);
     const out = stream.read().toString();
-    assert(out === sample);
+    assert(out === dedent`
+      # Coverage:
+      #
+      # not ok - 80% line coverage goal (missing) | ./src/missing.js
+    `);
+  });
+
+  test('percent trims trailing zeros but keeps two-decimal precision', () => {
+    const stream = new PassThrough();
+    const tap = new XTestCliTap({ stream, color: false, ...NOOP_URL_MAP });
+    tap.writeCoverage([
+      // 60.6000 → "60.6"; 60.6333 → "60.63"; 100.00 → "100"
+      { path: 'a', lines: { covered: 1, total: 1, percent: 60.6,  goal:  50, met: true, missing: false } },
+      { path: 'b', lines: { covered: 1, total: 1, percent: 60.63, goal:  50, met: true, missing: false } },
+      { path: 'c', lines: { covered: 1, total: 1, percent: 100,   goal: 100, met: true, missing: false } },
+    ]);
+    const out = stream.read().toString();
+    assert(out === dedent`
+      # Coverage:
+      #
+      # ok - 50%  line coverage goal (got 60.6%)  | a
+      # ok - 50%  line coverage goal (got 60.63%) | b
+      # ok - 100% line coverage goal (got 100%)   | c
+    `);
   });
 
   test('writeCoverage does not mutate tap.result', () => {
@@ -641,7 +678,7 @@ suite('coverage summary', () => {
       1..1
     `);
     const resultBefore = tap.result;
-    tap.writeCoverage(sample, { ok: true });
+    tap.writeCoverage([passingRow]);
     assert(tap.result === resultBefore);               // Same frozen snapshot.
   });
 });

--- a/x-test-cli-coverage.js
+++ b/x-test-cli-coverage.js
@@ -81,19 +81,19 @@ export class XTestCliCoverage {
    * URL-base algorithm, `'./src/foo.js'` maps to `http://<origin>/src/foo.js` —
    * which is exactly the form V8 reports for the served scripts.
    *
-   * Returns `{ ok, rows }`. `ok` is true iff every goal was met.
+   * Returns `{ ok, results }`. `ok` is true iff every goal was met.
    */
   static gradeCoverage({ entries, origin, goals }) {
     // Duplicate entries (same URL, different executions) merge into one so a
     //  file loaded twice is graded on the union of its observed coverage, not
     //  on whichever execution happened to be first in the list.
     const prepared = XTestCliCoverage.#filterAndMerge(entries, origin, goals);
-    const rows = [];
+    const results = [];
     for (const [path, spec] of Object.entries(goals)) {
       const resolvedUrl = new URL(path, origin + '/').href;
       const entry = prepared.find(item => item.url === resolvedUrl);
       if (!entry) {
-        rows.push({
+        results.push({
           path,
           resolvedUrl,
           lines: {
@@ -109,7 +109,7 @@ export class XTestCliCoverage {
       }
       const hits = XTestCliCoverage.computeLineHits(entry);
       const percent = hits.total === 0 ? 100 : XTestCliCoverage.#roundTwo(hits.covered / hits.total * 100);
-      rows.push({
+      results.push({
         path,
         resolvedUrl,
         lines: {
@@ -122,7 +122,7 @@ export class XTestCliCoverage {
         },
       });
     }
-    return { ok: rows.every(row => row.lines.met), rows };
+    return { ok: results.every(result => result.lines.met), results };
   }
 
   /**
@@ -182,57 +182,6 @@ export class XTestCliCoverage {
     const prepared = XTestCliCoverage.#filterAndMerge(entries, origin, goals);
     await writeFile(path, XTestCliCoverage.#formatLcov(prepared, { origin, sourceRoot }));
     return path;
-  }
-
-  /**
-   * TAP `#` diagnostic block for the coverage summary. Returns a single
-   * newline-joined string the caller writes to the TAP stream verbatim.
-   * Status token is native TAP vocabulary — `ok` / `not ok` — so readers
-   * who scan TAP already know what it means.
-   */
-  static formatCoverageBlock({ result }) {
-    // Columns we pad to max width across all rows:
-    //   status   — “ok” or “not ok”                 (max width: 6)
-    //   goal     — “65%” or “100%”                  (max width: 4)
-    //   got      — “(got 60.64%)” or “(missing)”
-    // Padding keeps the `| <path>` column visually aligned regardless of
-    //  which rows are missing or have short percentages.
-    const statusWidth = Math.max(0, ...result.rows.map(row => XTestCliCoverage.#statusOf(row).length));
-    const goalWidth   = Math.max(0, ...result.rows.map(row => `${row.lines.goal}%`.length));
-    const gotWidth    = Math.max(0, ...result.rows.map(row => XTestCliCoverage.#gotOf(row.lines).length));
-
-    const rows = result.rows.map(row => {
-      const status = XTestCliCoverage.#statusOf(row).padEnd(statusWidth, ' ');
-      const goal   = `${row.lines.goal}%`.padEnd(goalWidth, ' ');
-      const got    = XTestCliCoverage.#gotOf(row.lines).padEnd(gotWidth, ' ');
-      return `# ${status} - ${goal} line coverage goal ${got} | ${row.path}`;
-    });
-
-    return [
-      '# Coverage:',
-      '#',
-      ...rows,
-    ].join('\n');
-  }
-
-  static #statusOf(row) {
-    return row.lines.met ? 'ok' : 'not ok';
-  }
-
-  static #gotOf(lines) {
-    if (lines.missing) {
-      return '(missing)';
-    }
-    return `(got ${XTestCliCoverage.#formatPercent(lines.percent)}%)`;
-  }
-
-  /**
-   * Two decimal places, trailing zeros trimmed — so `100` stays `100`, `60.6`
-   * stays `60.6`, and `60.6333…` renders as `60.63`. Matches the shape the user
-   * specified without carrying spurious zeros.
-   */
-  static #formatPercent(value) {
-    return Number(value.toFixed(2)).toString();
   }
 
   /**

--- a/x-test-cli-tap.js
+++ b/x-test-cli-tap.js
@@ -104,21 +104,38 @@ export class XTestCliTap {
   }
 
   /**
-   * Render a CLI-produced `# Coverage:` diagnostic block. Styles every line
-   * uniformly — `red` when any goal failed, `dim` otherwise. The caller
-   * gates this entirely on test-pass: when tests fail, coverage is skipped
-   * (don't muddy a failing run with secondary signals). Routing this
-   * through `write()` would put it on the post-end raw-passthrough path,
-   * hence the dedicated entry point.
+   * Synthesize and render the `# Coverage:` block from structured grading
+   * rows. Styles every line uniformly — `red` when any goal failed, `dim`
+   * otherwise. Caller gates on test-pass: when tests fail, coverage is
+   * skipped (don't muddy a failing run with secondary signals). Routing
+   * this through `write()` would put it on the post-end raw-passthrough
+   * path, hence the dedicated entry point. Mirrors `#emitFailureBlock`'s
+   * "structured-data → comment-block" shape.
    */
-  writeCoverage(block, { ok }) {
+  writeCoverage(results) {
+    const ok = results.every(result => result.lines.met);
     const style = ok ? XTestCliTap.#styles.dim : XTestCliTap.#styles.red;
-    const lines = block.split(/\r?\n/);
-    if (lines.length > 0 && lines[lines.length - 1] === '') {
-      lines.pop();
-    }
-    for (const line of lines) {
-      this.#emit(line, style);
+    // Columns padded to max width across all results:
+    //   status — "ok" or "not ok"           (max width: 6)
+    //   goal   — "65%" or "100%"            (max width: 4)
+    //   got    — "(got 60.64%)" or "(missing)"
+    // Padding keeps the `| <path>` column aligned regardless of which
+    //  results are missing or have short percentages.
+    const statusOf = result => result.lines.met ? 'ok' : 'not ok';
+    const gotOf    = result => result.lines.missing
+      ? '(missing)'
+      : `(got ${Number(result.lines.percent.toFixed(2))}%)`;
+    const statusWidth = Math.max(0, ...results.map(result => statusOf(result).length));
+    const goalWidth   = Math.max(0, ...results.map(result => `${result.lines.goal}%`.length));
+    const gotWidth    = Math.max(0, ...results.map(result => gotOf(result).length));
+
+    this.#emit('# Coverage:', style);
+    this.#emit('#',           style);
+    for (const result of results) {
+      const status = statusOf(result).padEnd(statusWidth, ' ');
+      const goal   = `${result.lines.goal}%`.padEnd(goalWidth, ' ');
+      const got    = gotOf(result).padEnd(gotWidth, ' ');
+      this.#emit(`# ${status} - ${goal} line coverage goal ${got} | ${result.path}`, style);
     }
   }
 

--- a/x-test-cli.js
+++ b/x-test-cli.js
@@ -372,7 +372,7 @@ if (coverage && rawCoverageEntries && tap.result.ok) {
       goals:   options.coverageGoals,
     });
     coverageOk = graded.ok;
-    tap.writeCoverage(XTestCliCoverage.formatCoverageBlock({ result: graded }), { ok: graded.ok });
+    tap.writeCoverage(graded.results);
   } catch (error) {
     tap.write('Bail out! Coverage processing failed.');
     console.error(error); // eslint-disable-line no-console


### PR DESCRIPTION
We now simply format within the “tap” script.