### PR TITLE
Add CSS coverage support via “x-test.config.js“.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CSS coverage. `coverageGoals` keys may now target `.css` files alongside
+  `.js`; same `{ lines }` axis, same `lcov.info` output. Block-comment lines are
+  stripped from the CSS denominator (#29).
+
 ## [1.0.0-rc.7] - 2026-04-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ x-test — run TAP-compliant browser tests from the command line
                                 (required, or set in x-test.config.js)
 
   OPTIONS
-    --coverage <boolean>        Collect JS coverage via Chromium DevTools. Compares
-                                against goals defined in the config file and emits a
-                                diagnostic block after the run. Exits non-zero if a goal is
-                                not met. See “COVERAGE” below. Default: false.
-                                Only supported with chromium-based clients.
+    --coverage <boolean>        Collect JS and CSS coverage via Chromium DevTools.
+                                Compares against goals defined in the config file
+                                and emits a diagnostic block after the run. Exits
+                                non-zero if a goal is not met. See “COVERAGE”
+                                below. Default: false. Only supported with
+                                chromium-based clients.
 
     --root <path>               Disk side of the URL origin — the directory the dev
                                 server serves at “/”. Used to resolve “coverageGoals”
@@ -103,8 +104,14 @@ x-test — run TAP-compliant browser tests from the command line
     auto-disabled when “--name-pattern” is set — the numbers would only
     reflect the filtered subset of tests and misgrade the goals.
 
+    “coverageGoals” keys may target either JS or CSS files (or any path
+    served by the dev server); the same { lines } axis applies to both.
+    JS coverage comes from V8; CSS coverage comes from Chromium’s
+    rule-usage tracker — both are reported as line percentages.
+
     The following pragmas (matching “node:coverage” patterns) are
-    available and will be adhered to during coverage assessment:
+    available and will be adhered to during coverage assessment.
+    Block-comment syntax means they apply to JS and CSS alike:
 
       /* x-test:coverage disable */
       // ... region omitted from the report
@@ -185,10 +192,11 @@ browser-side runner via the `x-test-name-pattern` URL query param.
 
 ### Coverage
 
-When `--coverage=true`, the CLI collects V8 JS coverage via Chromium's DevTools
-Protocol, grades per-file goals declared in `x-test.config.js`, writes
-`./coverage/lcov.info`, and appends a `# Coverage:` diagnostic block to the
-TAP output.
+When `--coverage=true`, the CLI collects V8 JS coverage and CSS rule-usage
+coverage via Chromium's DevTools Protocol, grades per-file goals declared in
+`x-test.config.js`, writes `./coverage/lcov.info`, and appends a `# Coverage:`
+diagnostic block to the TAP output. JS and CSS files share the same
+`{ lines }` goal axis, so a single `coverageGoals` map can mix both.
 
 #### Config file
 
@@ -212,6 +220,7 @@ export default {
     './src/foo.js':        { lines: 100 },
     './src/bar.js':        { lines:  80 },
     './src/flaky-util.js': { lines:  60 },
+    './src/styles.css':    { lines:  90 },
   },
 };
 ```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,13 @@ export default [
     ...common,
   },
   {
+    // Browser-side integration test fixtures — run inside Chromium, not Node,
+    //  so they need browser globals (`document`, `window`, …) instead.
+    files: ['test/browser/**/*.js'],
+    languageOptions: { globals: globals.browser },
+    ...common,
+  },
+  {
     ignores: ['node_modules'],
   },
 ];

--- a/test/browser/index.css
+++ b/test/browser/index.css
@@ -1,0 +1,12 @@
+/* Linked stylesheet — exercises the standard `<link rel="stylesheet">`
+   path through CSS rule-usage tracking. The `h1` rule matches the page's
+   `<h1>` element so its bytes report as used; the `.unused` rule has no
+   match in the page, so its bytes report as not used. */
+
+h1 {
+  color: rebeccapurple;
+}
+
+.unused {
+  color: hotpink;
+}

--- a/test/browser/index.html
+++ b/test/browser/index.html
@@ -13,6 +13,7 @@
         }
       }
     </script>
+    <link rel="stylesheet" href="./index.css">
     <script type="module" src="./main.js"></script>
   </head>
   <body>

--- a/test/browser/subject.css
+++ b/test/browser/subject.css
@@ -1,0 +1,13 @@
+/* CSS-module-script stylesheet — imported from subject.js via
+   `import sheet from './subject.css' with { type: 'css' }` and adopted
+   onto the document. Exercises the constructed-stylesheet path through
+   CSS rule-usage tracking. The `body` rule matches; `#never-rendered`
+   does not. */
+
+body {
+  background: papayawhip;
+}
+
+#never-rendered {
+  background: tomato;
+}

--- a/test/browser/subject.js
+++ b/test/browser/subject.js
@@ -1,6 +1,12 @@
 // Minimal module under test — exists only so the integration test has
 //  something to exercise for coverage purposes. Keep tiny and stable.
 
+// CSS module script: imported with `type: 'css'` and adopted onto the
+//  document so its rules participate in CSS rule-usage tracking. This
+//  is the constructed-stylesheet half of the integration test.
+import sheet from './subject.css' with { type: 'css' };
+document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+
 export function add(a, b) {
   return a + b;
 }

--- a/test/node/browser.test.js
+++ b/test/node/browser.test.js
@@ -91,6 +91,51 @@ suite('XTestCliBrowserPlaywright.normalizeCoverage', () => {
   });
 });
 
+suite('XTestCliBrowserPlaywright.normalizeCssCoverage', () => {
+  test('preserves url, text, and {start, end} ranges', () => {
+    const input = [{
+      url: 'http://example/a.css',
+      text: 'a { color: red; }',
+      ranges: [{ start: 0, end: 17 }],
+    }];
+    const [entry] = XTestCliBrowserPlaywright.normalizeCssCoverage(input);
+    assert(entry.url === 'http://example/a.css');
+    assert(entry.text === 'a { color: red; }');
+    assert.deepEqual(entry.ranges, [{ start: 0, end: 17 }]);
+  });
+
+  test('handles missing ranges array', () => {
+    const input = [{ url: 'u', text: 'x' }];
+    const [entry] = XTestCliBrowserPlaywright.normalizeCssCoverage(input);
+    assert.deepEqual(entry.ranges, []);
+  });
+
+  test('handles empty input', () => {
+    assert.deepEqual(XTestCliBrowserPlaywright.normalizeCssCoverage([]), []);
+  });
+
+  test('handles multiple ranges within an entry', () => {
+    const input = [{
+      url: 'u', text: 'abcdefghij',
+      ranges: [{ start: 0, end: 3 }, { start: 5, end: 7 }],
+    }];
+    const [entry] = XTestCliBrowserPlaywright.normalizeCssCoverage(input);
+    assert.deepEqual(entry.ranges, [
+      { start: 0, end: 3 },
+      { start: 5, end: 7 },
+    ]);
+  });
+
+  test('drops extra fields on ranges (defensive shape copy)', () => {
+    const input = [{
+      url: 'u', text: 'x',
+      ranges: [{ start: 0, end: 1, extra: 'unexpected' }],
+    }];
+    const [entry] = XTestCliBrowserPlaywright.normalizeCssCoverage(input);
+    assert.deepEqual(entry.ranges, [{ start: 0, end: 1 }]);
+  });
+});
+
 suite('XTestCliBrowserPlaywright.convertToDisjointRanges', () => {
   test('single covered range passes through', () => {
     const out = XTestCliBrowserPlaywright.convertToDisjointRanges([

--- a/test/node/coverage.test.js
+++ b/test/node/coverage.test.js
@@ -6,9 +6,12 @@ import { join } from 'node:path';
 import { XTestCliCoverage } from '../../x-test-cli-coverage.js';
 import { dedent } from './common.js';
 
-/** Build a V8-shaped entry (Puppeteer post-normalization). */
+/** Build a V8-shaped entry (Puppeteer post-normalization). `kind` is
+ *  set explicitly because the production code requires it — there is no
+ *  silent default in `#filterAndMerge` or `computeLineHits`. CSS-shaped
+ *  fixtures pass `kind: 'css'` directly inline. */
 function entry(url, text, ranges) {
-  return { url, text, ranges };
+  return { url, text, ranges, kind: 'js' };
 }
 
 /** Cover the entire text with one range — useful for "all hit" fixtures. */
@@ -124,14 +127,14 @@ suite('XTestCliCoverage.computeLineHits — pragmas', () => {
 });
 
 suite('XTestCliCoverage.gradeCoverage', () => {
-  const origin = 'http://host';
+  const baseUrl = 'http://host/';
 
   test('all goals met → ok: true', () => {
     const text = 'a;\nb;\nc;';
     const entries = [entry('http://host/src/a.js', text, all(text))];
     const result = XTestCliCoverage.gradeCoverage({
       entries,
-      origin,
+      baseUrl,
       goals:   { './src/a.js': { lines: 100 } },
     });
     assert(result.ok === true);
@@ -147,7 +150,7 @@ suite('XTestCliCoverage.gradeCoverage', () => {
     const entries = [entry('http://host/src/a.js', text, [{ start: 0, end: 2 }])];
     const result = XTestCliCoverage.gradeCoverage({
       entries,
-      origin,
+      baseUrl,
       goals:   { './src/a.js': { lines: 100 } },
     });
     assert(result.ok === false);
@@ -158,7 +161,7 @@ suite('XTestCliCoverage.gradeCoverage', () => {
   test('missing goal file → row flagged missing, not met', () => {
     const result = XTestCliCoverage.gradeCoverage({
       entries: [],
-      origin,
+      baseUrl,
       goals:   { './src/missing.js': { lines: 80 } },
     });
     assert(result.ok === false);
@@ -173,7 +176,7 @@ suite('XTestCliCoverage.gradeCoverage', () => {
     const entries = [entry('http://host/src/a.js', text, [{ start: 0, end: 2 }])];
     const result = XTestCliCoverage.gradeCoverage({
       entries,
-      origin,
+      baseUrl,
       goals:   { './src/a.js': { lines: 30 } },
     });
     assert(result.results[0].lines.percent === 33.33);
@@ -197,7 +200,7 @@ suite('XTestCliCoverage.synthesizeMissingEntries', () => {
   test('returns synthetic entries for goals on disk but not in entries', async () => {
     const synthetic = await XTestCliCoverage.synthesizeMissingEntries({
       entries: [],
-      origin: 'http://host',
+      baseUrl: 'http://host/',
       sourceRoot: dir,
       goals:   { './src/onDisk.js': { lines: 80 } },
     });
@@ -215,7 +218,7 @@ suite('XTestCliCoverage.synthesizeMissingEntries', () => {
     };
     const synthetic = await XTestCliCoverage.synthesizeMissingEntries({
       entries: [existing],
-      origin: 'http://host',
+      baseUrl: 'http://host/',
       sourceRoot: dir,
       goals:   { './src/onDisk.js': { lines: 80 } },
     });
@@ -225,7 +228,7 @@ suite('XTestCliCoverage.synthesizeMissingEntries', () => {
   test('silently skips goals that are not on disk either', async () => {
     const synthetic = await XTestCliCoverage.synthesizeMissingEntries({
       entries: [],
-      origin: 'http://host',
+      baseUrl: 'http://host/',
       sourceRoot: dir,
       goals:   { './src/does-not-exist.js': { lines: 80 } },
     });
@@ -235,13 +238,13 @@ suite('XTestCliCoverage.synthesizeMissingEntries', () => {
   test('synthetic entries grade as 0/N not ok and flow into lcov', async () => {
     const synthetic = await XTestCliCoverage.synthesizeMissingEntries({
       entries: [],
-      origin: 'http://host',
+      baseUrl: 'http://host/',
       sourceRoot: dir,
       goals:   { './src/onDisk.js': { lines: 80 } },
     });
     const graded = XTestCliCoverage.gradeCoverage({
       entries: synthetic,
-      origin: 'http://host',
+      baseUrl: 'http://host/',
       goals:   { './src/onDisk.js': { lines: 80 } },
     });
     assert(graded.ok === false);
@@ -254,6 +257,11 @@ suite('XTestCliCoverage.synthesizeMissingEntries', () => {
 });
 
 suite('XTestCliCoverage.writeLcov', () => {
+  // `writeLcov` requires baseUrl + sourceRoot; production always supplies
+  //  both. `sourceRoot` of '/' makes URL paths like '/x.js' decode + strip
+  //  to 'x.js', which is what the SF assertions below expect.
+  const baseUrl    = 'http://host/';
+  const sourceRoot = '/';
   let dir;
 
   before(async () => {
@@ -272,11 +280,11 @@ suite('XTestCliCoverage.writeLcov', () => {
       'c;',                                            // Line 5 — covered.
     ].join('\n');
     const entries = [entry('http://host/x.js', text, all(text))];
-    const written = await XTestCliCoverage.writeLcov({ entries, outDir: dir });
+    const written = await XTestCliCoverage.writeLcov({ entries, outDir: dir, baseUrl, sourceRoot });
     const body = await readFile(written, 'utf8');
     const expected = [
       'TN:',
-      'SF:http://host/x.js',
+      'SF:x.js',
       'DA:1,1',
       'DA:5,1',
       'LF:2',
@@ -290,20 +298,20 @@ suite('XTestCliCoverage.writeLcov', () => {
   test('multiple entries → multiple records', async () => {
     const a = entry('http://host/a.js', 'x;', all('x;'));
     const b = entry('http://host/b.js', 'y;', all('y;'));
-    const written = await XTestCliCoverage.writeLcov({ entries: [a, b], outDir: dir });
+    const written = await XTestCliCoverage.writeLcov({ entries: [a, b], outDir: dir, baseUrl, sourceRoot });
     const body = await readFile(written, 'utf8');
     const records = body.split('end_of_record\n').filter(s => s !== '');
     assert(records.length === 2);
     assert(records[0] === dedent`
       TN:
-      SF:http://host/a.js
+      SF:a.js
       DA:1,1
       LF:1
       LH:1
     `);
     assert(records[1] === dedent`
       TN:
-      SF:http://host/b.js
+      SF:b.js
       DA:1,1
       LF:1
       LH:1
@@ -316,11 +324,12 @@ suite('XTestCliCoverage.writeLcov', () => {
     const written = await XTestCliCoverage.writeLcov({
       entries: [targeted, untargeted],
       outDir:  dir,
-      origin:  'http://host',
+      baseUrl,
+      sourceRoot,
       goals:   { './src/app.js': { lines: 50 } },
     });
     const body = await readFile(written, 'utf8');
-    assert(body.includes('SF:http://host/src/app.js\n'));
+    assert(body.includes('SF:src/app.js\n'));
     assert(body.includes('test/t.html') === false);
   });
 
@@ -333,7 +342,8 @@ suite('XTestCliCoverage.writeLcov', () => {
     const written = await XTestCliCoverage.writeLcov({
       entries: [first, second],
       outDir:  dir,
-      origin:  'http://host',
+      baseUrl,
+      sourceRoot,
       goals:   { './x.js': { lines: 100 } },
     });
     const body = await readFile(written, 'utf8');
@@ -347,7 +357,7 @@ suite('XTestCliCoverage.writeLcov', () => {
     const text = 'a;\nb;';
     // Cover only line 1.
     const entries = [entry('http://host/p.js', text, [{ start: 0, end: 2 }])];
-    const written = await XTestCliCoverage.writeLcov({ entries, outDir: dir });
+    const written = await XTestCliCoverage.writeLcov({ entries, outDir: dir, baseUrl, sourceRoot });
     const body = await readFile(written, 'utf8');
     assert(body.includes('DA:1,1'));
     assert(body.includes('DA:2,0'));
@@ -361,7 +371,7 @@ suite('XTestCliCoverage.writeLcov', () => {
   test('partial line → DA:N,1 plus synthesized BRDA pair', async () => {
     const text = 'abc def';                            // One line; "abc" covered, "def" not.
     const entries = [entry('http://host/partial.js', text, [{ start: 0, end: 3 }])];
-    const written = await XTestCliCoverage.writeLcov({ entries, outDir: dir });
+    const written = await XTestCliCoverage.writeLcov({ entries, outDir: dir, baseUrl, sourceRoot });
     const body = await readFile(written, 'utf8');
     assert(body.includes('DA:1,1\n'));                 // Hit in lcov terms.
     assert(body.includes('BRDA:1,0,0,1\n'));           // Synthesized "taken" branch.
@@ -378,7 +388,7 @@ suite('XTestCliCoverage.writeLcov', () => {
   test('fully-covered file has no BRDA records', async () => {
     const text = 'const x = 1;';
     const entries = [entry('http://host/clean.js', text, all(text))];
-    const written = await XTestCliCoverage.writeLcov({ entries, outDir: dir });
+    const written = await XTestCliCoverage.writeLcov({ entries, outDir: dir, baseUrl, sourceRoot });
     const body = await readFile(written, 'utf8');
     assert(body.includes('BRDA:') === false);
     assert(body.includes('BRF:')  === false);
@@ -390,23 +400,11 @@ suite('XTestCliCoverage.writeLcov', () => {
     const written = await XTestCliCoverage.writeLcov({
       entries,
       outDir: dir,
-      origin: 'http://host:8080',
+      baseUrl: 'http://host:8080/',
       sourceRoot: '/project/root',
     });
     const body = await readFile(written, 'utf8');
     assert(body.includes('SF:src/a.js\n'));
-  });
-
-  test('SF leaves cross-origin URLs as URLs', async () => {
-    const entries = [entry('http://elsewhere/lib.js', 'x;', all('x;'))];
-    const written = await XTestCliCoverage.writeLcov({
-      entries,
-      outDir: dir,
-      origin: 'http://host:8080',
-      sourceRoot: '/project/root',
-    });
-    const body = await readFile(written, 'utf8');
-    assert(body.includes('SF:http://elsewhere/lib.js\n'));
   });
 
   test('SF decodes percent-escapes in the pathname', async () => {
@@ -414,10 +412,149 @@ suite('XTestCliCoverage.writeLcov', () => {
     const written = await XTestCliCoverage.writeLcov({
       entries,
       outDir: dir,
-      origin: 'http://host',
+      baseUrl: 'http://host/',
       sourceRoot: '/root',
     });
     const body = await readFile(written, 'utf8');
     assert(body.includes('SF:src/a b.js\n'));
+  });
+});
+
+suite('XTestCliCoverage — CSS coverage entries', () => {
+  // CSS coverage entries arrive in the same `{url, text, ranges}` shape as JS
+  //  (after each driver's normalization) — only the `kind` tag distinguishes
+  //  them. The line-hit / grading / lcov pipeline is language-agnostic, so
+  //  these tests verify it works end-to-end on CSS-shaped input and on the
+  //  edge case where a single URL has both JS and CSS entries.
+
+  test('computeLineHits classifies a CSS file like any other', () => {
+    const text = 'a { color: red; }\nb { color: blue; }';
+    const ranges = [{ start: 0, end: 17 }];                // First rule only.
+    const hits = XTestCliCoverage.computeLineHits({ url: 'u', text, ranges, kind: 'css' });
+    assert(hits.total   === 2);
+    assert(hits.covered === 1);
+    assert(hits.hitMap.get(1) === 'full');
+    assert(hits.hitMap.get(2) === 'none');
+  });
+
+  test('gradeCoverage scores a CSS goal', () => {
+    const text = 'a { color: red; }\nb { color: blue; }';
+    const entries = [{
+      url: 'http://host/src/styles.css',
+      text,
+      ranges: [{ start: 0, end: 17 }],
+      kind: 'css',
+    }];
+    const result = XTestCliCoverage.gradeCoverage({
+      entries,
+      baseUrl: 'http://host/',
+      goals:  { './src/styles.css': { lines: 50 } },
+    });
+    assert(result.ok === true);
+    assert(result.results[0].lines.percent === 50);
+    assert(result.results[0].lines.met     === true);
+  });
+
+  test('CSS block-comment lines are stripped from the denominator', () => {
+    // Header comment + two rules. With comment-stripping, only the rule
+    //  lines count toward the total. CSS rule-usage tracking marks the
+    //  matched rule's bytes as covered, so coverage = matched-rule lines /
+    //  all-rule lines = 50%.
+    const text = [
+      '/* a multi-line',                                 // Comment-only — dropped.
+      '   header comment',                               // Comment-only — dropped.
+      '   describing this file. */',                     // Comment-only — dropped.
+      'h1 {',                                            // Counts. Matched rule.
+      '  color: red;',                                   // Counts. Matched rule.
+      '}',                                               // Counts. Matched rule.
+      '.unused {',                                       // Counts. Unmatched rule.
+      '  color: blue;',                                  // Counts. Unmatched rule.
+      '}',                                               // Counts. Unmatched rule.
+    ].join('\n');
+    const ranges = [{ start: 0, end: text.indexOf('.unused') }]; // h1 rule only.
+    const hits = XTestCliCoverage.computeLineHits({ url: 'u', text, ranges, kind: 'css' });
+    assert(hits.total   === 6);                          // 3 + 3, comment lines stripped.
+    assert(hits.covered === 3);                          // Matched rule's lines.
+  });
+
+  test('JS comment lines still count (V8 already covers them)', () => {
+    // Symmetry check: the comment-stripping pass is CSS-only. A JS file
+    //  with a comment-only line that happens to be uncovered should
+    //  remain in the denominator.
+    const text = [
+      '// not a real line comment in this test',         // Counts as JS.
+      'const a = 1;',                                    // Counts.
+    ].join('\n');
+    // Cover only line 2.
+    const ranges = [{ start: text.indexOf('const'), end: text.length }];
+    const hits = XTestCliCoverage.computeLineHits({ url: 'u', text, ranges, kind: 'js' });
+    assert(hits.total === 2);                            // No stripping.
+  });
+
+  test('mid-line CSS comment does not alter classification of significant chars', () => {
+    // A rule with a trailing same-line comment: the rule's bytes are
+    //  covered, the comment bytes are skipped from classification, so the
+    //  line ends up `'full'` rather than `'partial'`.
+    const text = 'h1 { color: red; } /* trailing */';
+    const ruleEnd = text.indexOf('}') + 1;
+    const ranges = [{ start: 0, end: ruleEnd }];
+    const hits = XTestCliCoverage.computeLineHits({ url: 'u', text, ranges, kind: 'css' });
+    assert(hits.total === 1);
+    assert(hits.covered === 1);
+    assert(hits.hitMap.get(1) === 'full');
+  });
+
+  test('unterminated CSS block comment masks to end of file', () => {
+    const text = 'h1 { color: red; }\n/* never closed';
+    const ranges = [{ start: 0, end: 18 }];
+    const hits = XTestCliCoverage.computeLineHits({ url: 'u', text, ranges, kind: 'css' });
+    assert(hits.total === 1);                            // Comment-only line dropped.
+    assert(hits.covered === 1);
+  });
+
+  test('CSS pragmas (block-comment) exclude lines from grading', () => {
+    const text = [
+      'a { color: red; }',                                 // Line 1 — counts.
+      '/* x-test:coverage disable */',                     // Line 2 — pragma.
+      'b { color: blue; }',                                // Line 3 — disabled.
+      '/* x-test:coverage enable */',                      // Line 4 — pragma.
+      'c { color: green; }',                               // Line 5 — counts.
+    ].join('\n');
+    const hits = XTestCliCoverage.computeLineHits({ url: 'u', text, ranges: all(text), kind: 'css' });
+    assert(hits.total   === 2);                            // Lines 1, 5.
+    assert(hits.covered === 2);
+  });
+
+  test('same URL with both JS and CSS kinds does not collide in the merge', async () => {
+    // Edge case: theoretically possible with CSS module scripts. Both entries
+    //  must survive into lcov as separate records keyed off (url, kind).
+    const tmp = await mkdtemp(join(tmpdir(), 'x-test-cli-mixed-'));
+    try {
+      const jsEntry = {
+        url: 'http://host/x.module',
+        text: 'export default 1;',
+        ranges: [{ start: 0, end: 17 }],
+        kind: 'js',
+      };
+      const cssEntry = {
+        url: 'http://host/x.module',
+        text: 'a { color: red; }',
+        ranges: [{ start: 0, end: 17 }],
+        kind: 'css',
+      };
+      const written = await XTestCliCoverage.writeLcov({
+        entries: [jsEntry, cssEntry],
+        outDir:  tmp,
+        baseUrl: 'http://host/',
+        sourceRoot: '/',
+        goals:   { './x.module': { lines: 100 } },
+      });
+      const body = await readFile(written, 'utf8');
+      // Two SF records for the same path — one per kind.
+      const records = body.split('end_of_record').filter(s => s.trim() !== '');
+      assert(records.length === 2);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/x-test-cli-browser.js
+++ b/x-test-cli-browser.js
@@ -3,7 +3,9 @@
  * browser console line through `onConsole(text)`, awaits `ended` (the caller’s
  * signal that the TAP stream has terminated — typically a Promise resolved by
  * the TAP parser when it sees a top-level plan or `Bail out!`), surfaces V8
- * coverage via `onCoverage(entries)`, and closes.
+ * and CSS coverage via `onCoverage(entries)`, and closes. Entries are tagged
+ * with `kind` (`'js'` or `'css'`) so downstream merging can disambiguate the
+ * (theoretical) case of one URL appearing in both collectors.
  */
 export class XTestCliBrowserPuppeteer {
   static async run({ url, coverage, launchOptions, launchTimeout, onConsole, onCoverage, ended }) {
@@ -27,7 +29,10 @@ export class XTestCliBrowserPuppeteer {
       });
 
       if (coverage) {
-        await page.coverage.startJSCoverage();
+        await Promise.all([
+          page.coverage.startJSCoverage(),
+          page.coverage.startCSSCoverage(),
+        ]);
       }
 
       await page.setExtraHTTPHeaders({ Accept: 'text/html' });
@@ -39,9 +44,17 @@ export class XTestCliBrowserPuppeteer {
       await ended;
 
       if (coverage) {
-        // Puppeteer already emits `{text, ranges}` — no normalization needed.
-        const js = await page.coverage.stopJSCoverage();
-        onCoverage(js);
+        // Puppeteer already emits `{text, ranges}` for both JS and CSS — no
+        //  normalization needed. Tag with `kind` and concatenate.
+        const [js, css] = await Promise.all([
+          page.coverage.stopJSCoverage(),
+          page.coverage.stopCSSCoverage(),
+        ]);
+        const tagged = [
+          ...js.map(entry  => ({ ...entry, kind: 'js'  })),
+          ...css.map(entry => ({ ...entry, kind: 'css' })),
+        ];
+        onCoverage(tagged);
       }
     } finally {
       await browser.close();
@@ -79,7 +92,10 @@ export class XTestCliBrowserPlaywright {
       });
 
       if (coverage) {
-        await page.coverage.startJSCoverage();
+        await Promise.all([
+          page.coverage.startJSCoverage(),
+          page.coverage.startCSSCoverage(),
+        ]);
       }
 
       await page.setExtraHTTPHeaders({ Accept: 'text/html' });
@@ -91,9 +107,15 @@ export class XTestCliBrowserPlaywright {
       await ended;
 
       if (coverage) {
-        const raw = await page.coverage.stopJSCoverage();
-        const js = XTestCliBrowserPlaywright.normalizeCoverage(raw);
-        onCoverage(js);
+        const [rawJs, rawCss] = await Promise.all([
+          page.coverage.stopJSCoverage(),
+          page.coverage.stopCSSCoverage(),
+        ]);
+        const js  = XTestCliBrowserPlaywright.normalizeCoverage(rawJs)
+          .map(entry => ({ ...entry, kind: 'js' }));
+        const css = XTestCliBrowserPlaywright.normalizeCssCoverage(rawCss)
+          .map(entry => ({ ...entry, kind: 'css' }));
+        onCoverage([...js, ...css]);
       }
     } finally {
       await browser.close();
@@ -119,6 +141,22 @@ export class XTestCliBrowserPlaywright {
       }
       return { url, scriptId, text: source, ranges: XTestCliBrowserPlaywright.convertToDisjointRanges(nested) };
     });
+  }
+
+  /**
+   * Pass Playwright’s raw CSS coverage through with a defensive shape copy.
+   * Playwright already emits `{url, text, ranges:[{start, end}]}` — same
+   * shape as Puppeteer’s CSS coverage — so unlike `normalizeCoverage`
+   * (which has to flatten V8’s nested function ranges) this is just a
+   * shallow remap that drops any extra fields and guards against a
+   * missing `ranges` array.
+   */
+  static normalizeCssCoverage(entries) {
+    return entries.map(({ url, text, ranges }) => ({
+      url,
+      text,
+      ranges: (ranges ?? []).map(range => ({ start: range.start, end: range.end })),
+    }));
   }
 
   /**

--- a/x-test-cli-coverage.js
+++ b/x-test-cli-coverage.js
@@ -21,6 +21,8 @@ export class XTestCliCoverage {
   static #CODE_FORMFEED = 0x0c; // '\f'
   static #CODE_LF       = 0x0a; // '\n'
   static #CODE_CR       = 0x0d; // '\r'
+  static #CODE_SLASH    = 0x2f; // '/'
+  static #CODE_STAR     = 0x2a; // '*'
 
   /**
    * Per-line coverage for a single V8 entry.
@@ -46,11 +48,18 @@ export class XTestCliCoverage {
    * numerator and the denominator.
    */
   static computeLineHits(entry) {
-    const { text, ranges } = entry;
+    const { text, ranges, kind } = entry;
     const spans = XTestCliCoverage.#lineSpans(text);
     const lines = spans.map(([s, e]) => text.slice(s, e));
     const ignored = XTestCliCoverage.#parsePragmas(lines);
     const covered = XTestCliCoverage.#coverageMap(text.length, ranges);
+    // CSS rule-usage tracking only marks matched-rule byte ranges as used,
+    //  so lines that are entirely inside `/* ... */` block comments would
+    //  otherwise drag the denominator down without ever being counted as
+    //  covered. Strip them here, the same way blank lines and pragma-ignored
+    //  lines are stripped. JS doesn't need this — V8's executed-scope ranges
+    //  already cover comment bytes — so the mask is built only for CSS.
+    const commentMask = kind === 'css' ? XTestCliCoverage.#cssCommentMask(text) : null;
 
     const hitMap = new Map();
     let total = 0;
@@ -64,8 +73,11 @@ export class XTestCliCoverage {
       if (XTestCliCoverage.#isBlank(lines[index])) {
         continue;
       }
+      if (commentMask && XTestCliCoverage.#isAllCommentOrBlank(text, spans[index], commentMask)) {
+        continue;
+      }
       total++;
-      const state = XTestCliCoverage.#classifyLine(text, spans[index], covered);
+      const state = XTestCliCoverage.#classifyLine(text, spans[index], covered, commentMask);
       if (state === 'full') {
         hits++;
       }
@@ -77,20 +89,20 @@ export class XTestCliCoverage {
 
   /**
    * Grade the configured `goals` against the collected V8 `entries`. Goal paths
-   * are resolved against `origin` (the test URL’s origin) using the standard
-   * URL-base algorithm, `'./src/foo.js'` maps to `http://<origin>/src/foo.js` —
-   * which is exactly the form V8 reports for the served scripts.
+   * are resolved against `baseUrl` (the test URL’s origin with trailing `/`)
+   * using the standard URL-base algorithm, so `'./src/foo.js'` maps to
+   * `<baseUrl>src/foo.js` — exactly the form V8 reports for the served scripts.
    *
    * Returns `{ ok, results }`. `ok` is true iff every goal was met.
    */
-  static gradeCoverage({ entries, origin, goals }) {
+  static gradeCoverage({ entries, baseUrl, goals }) {
     // Duplicate entries (same URL, different executions) merge into one so a
     //  file loaded twice is graded on the union of its observed coverage, not
     //  on whichever execution happened to be first in the list.
-    const prepared = XTestCliCoverage.#filterAndMerge(entries, origin, goals);
+    const prepared = XTestCliCoverage.#filterAndMerge(entries, baseUrl, goals);
     const results = [];
     for (const [path, spec] of Object.entries(goals)) {
-      const resolvedUrl = new URL(path, origin + '/').href;
+      const resolvedUrl = new URL(path, baseUrl).href;
       const entry = prepared.find(item => item.url === resolvedUrl);
       if (!entry) {
         results.push({
@@ -137,18 +149,21 @@ export class XTestCliCoverage {
    * `gradeCoverage`’s `missing` path, which keeps the explicit “file not
    * found” notation for true typos in config.
    */
-  static async synthesizeMissingEntries({ entries, origin, sourceRoot, goals }) {
+  static async synthesizeMissingEntries({ entries, baseUrl, sourceRoot, goals }) {
     const known = new Set(entries.map(item => item.url));
     const synthetic = [];
     for (const path of Object.keys(goals ?? {})) {
-      const resolvedUrl = new URL(path, origin + '/').href;
+      const resolvedUrl = new URL(path, baseUrl).href;
       if (known.has(resolvedUrl)) {
         continue;
       }
       const diskPath = resolvePath(sourceRoot, path);
       try {
         const text = await readFile(diskPath, 'utf8');
-        synthetic.push({ url: resolvedUrl, text, ranges: [] });
+        // `kind` defaults to `'js'`. Synthesized entries always carry empty
+        //  ranges, so the value only matters as the merge-key suffix in
+        //  `#filterAndMerge`; default is correct for any non-collision case.
+        synthetic.push({ url: resolvedUrl, text, ranges: [], kind: 'js' });
       } catch {
         // Goal’s file doesn’t exist on disk either — leave it to
         //  gradeCoverage’s “missing” path so the row shows “file not found”.
@@ -168,19 +183,19 @@ export class XTestCliCoverage {
    * each targeted file appears once in `lcov.info`, with the union of all
    * observed covered ranges.
    *
-   * `origin` and `sourceRoot` together produce filesystem paths in `SF:`
+   * `baseUrl` and `sourceRoot` together produce filesystem paths in `SF:`
    * records (what lcov consumers like VSCode Coverage Gutters expect). Paths
    * are emitted **relative to `sourceRoot`** so the report stays portable
    * across machines and CI uploads.
    *
    * Resolves to the absolute path written.
    */
-  static async writeLcov({ entries, outDir, origin, sourceRoot, goals }) {
+  static async writeLcov({ entries, outDir, baseUrl, sourceRoot, goals }) {
     const dir = resolvePath(outDir);
     await mkdir(dir, { recursive: true });
     const path = resolvePath(dir, 'lcov.info');
-    const prepared = XTestCliCoverage.#filterAndMerge(entries, origin, goals);
-    await writeFile(path, XTestCliCoverage.#formatLcov(prepared, { origin, sourceRoot }));
+    const prepared = XTestCliCoverage.#filterAndMerge(entries, baseUrl, goals);
+    await writeFile(path, XTestCliCoverage.#formatLcov(prepared, { sourceRoot }));
     return path;
   }
 
@@ -279,17 +294,21 @@ export class XTestCliCoverage {
   }
 
   /**
-   * Three-state classification of a line, ignoring whitespace bytes. Returns
-   * `'full'` when every non-whitespace byte lies in a covered range, `'none'`
-   * when none do, and `'partial'` when the line straddles the boundary (e.g.,
-   * a one-line `if / else` where only one branch ran).
+   * Three-state classification of a line, ignoring whitespace bytes — and,
+   * when a `commentMask` is supplied, bytes that fall inside CSS block
+   * comments. Returns `'full'` when every significant byte lies in a covered
+   * range, `'none'` when none do, and `'partial'` when the line straddles
+   * the boundary (e.g., a one-line `if / else` where only one branch ran).
    */
-  static #classifyLine(text, span, covered) {
+  static #classifyLine(text, span, covered, commentMask) {
     const [start, end] = span;
     let anyCovered   = false;
     let anyUncovered = false;
     for (let index = start; index < end; index++) {
       if (XTestCliCoverage.#isWhitespaceCode(text.charCodeAt(index))) {
+        continue;
+      }
+      if (commentMask && commentMask[index]) {
         continue;
       }
       if (covered[index]) {
@@ -302,6 +321,65 @@ export class XTestCliCoverage {
       }
     }
     return anyCovered ? 'full' : 'none';
+  }
+
+  /**
+   * True iff every byte on `[span.start, span.end)` is whitespace or part of
+   * a CSS block comment per `commentMask`. Used to drop comment-only lines
+   * from the denominator the same way `#isBlank` drops whitespace-only lines.
+   */
+  static #isAllCommentOrBlank(text, span, commentMask) {
+    const [start, end] = span;
+    for (let index = start; index < end; index++) {
+      if (XTestCliCoverage.#isWhitespaceCode(text.charCodeAt(index))) {
+        continue;
+      }
+      if (commentMask[index]) {
+        continue;
+      }
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Build a byte-mask for CSS block comments: `mask[i] === 1` iff char `i`
+   * lies within a slash-star … star-slash span (markers themselves
+   * included). CSS has no line-comment syntax and no nested comments, so
+   * the algorithm is a simple scan for an opener and the next closer.
+   * Unterminated comments mark to end of text — defensive, since
+   * unterminated comments are also a parse error for the browser, but
+   * harmless here either way.
+   *
+   * Strings (`"…"` / `'…'`) are not tracked. CSS rarely embeds comment
+   * markers inside string values, and the worst case if it ever happens is
+   * over-stripping — at most a line or two excluded that arguably shouldn't
+   * be. Not worth the parser complexity to handle precisely.
+   */
+  static #cssCommentMask(text) {
+    const mask = new Uint8Array(text.length);
+    let index = 0;
+    while (index < text.length - 1) {
+      if (text.charCodeAt(index) === XTestCliCoverage.#CODE_SLASH
+        && text.charCodeAt(index + 1) === XTestCliCoverage.#CODE_STAR) {
+        let close = index + 2;
+        while (close < text.length - 1) {
+          if (text.charCodeAt(close) === XTestCliCoverage.#CODE_STAR
+            && text.charCodeAt(close + 1) === XTestCliCoverage.#CODE_SLASH) {
+            break;
+          }
+          close++;
+        }
+        const stop = close < text.length - 1 ? close + 2 : text.length;
+        for (let mark = index; mark < stop; mark++) {
+          mask[mark] = 1;
+        }
+        index = stop;
+      } else {
+        index++;
+      }
+    }
+    return mask;
   }
 
   static #isWhitespaceCode(code) {
@@ -333,7 +411,7 @@ export class XTestCliCoverage {
    *
    * Whitespace-only and pragma-ignored lines are omitted from all records.
    */
-  static #formatLcov(entries, { origin, sourceRoot } = {}) {
+  static #formatLcov(entries, { sourceRoot }) {
     const records = [];
     for (const entry of entries) {
       const hits = XTestCliCoverage.computeLineHits(entry);
@@ -366,7 +444,7 @@ export class XTestCliCoverage {
 
       const body = [
         'TN:',
-        `SF:${XTestCliCoverage.#sourceFile(entry.url, origin, sourceRoot)}`,
+        `SF:${XTestCliCoverage.#sourceFile(entry.url, sourceRoot)}`,
         ...daRecords,
         `LF:${lineTotal}`,
         `LH:${lineHits}`,
@@ -389,51 +467,48 @@ export class XTestCliCoverage {
    * records per targeted file. We concatenate ranges without merging
    * overlapping spans: `#coverageMap` ORs them together, so any overlap is
    * already handled correctly at the byte level.
+   *
+   * Merge key is `(url, kind)` rather than `url` alone so the (theoretical)
+   * case of a single URL producing both JS and CSS coverage entries — e.g. a
+   * CSS module script — keeps the two streams separate. Each kind grades and
+   * renders independently in lcov.
    */
-  static #filterAndMerge(entries, origin, goals) {
-    const goalUrls = (goals && origin)
-      ? new Set(Object.keys(goals).map(path => new URL(path, origin + '/').href))
+  static #filterAndMerge(entries, baseUrl, goals) {
+    const goalUrls = (goals && baseUrl)
+      ? new Set(Object.keys(goals).map(path => new URL(path, baseUrl).href))
       : null;
-    const byUrl = new Map();
+    const byKey = new Map();
     for (const entry of entries) {
       if (goalUrls && !goalUrls.has(entry.url)) {
         continue;
       }
-      const existing = byUrl.get(entry.url);
+      const key = `${entry.url}::${entry.kind}`;
+      const existing = byKey.get(key);
       if (existing) {
         existing.ranges = existing.ranges.concat(entry.ranges);
       } else {
-        byUrl.set(entry.url, { url: entry.url, text: entry.text, ranges: [...entry.ranges] });
+        const { url, text, ranges, kind } = entry;
+        byKey.set(key, { url, text, ranges: [...ranges], kind });
       }
     }
-    return [...byUrl.values()];
+    return [...byKey.values()];
   }
 
   /**
-   * Map a V8 entry URL to the `SF:` value for its lcov record. When the URL
-   * shares `origin`, return a filesystem path **relative to `sourceRoot`** —
-   * the convention every major lcov consumer (Codecov, Coveralls, SonarQube,
-   * VSCode Coverage Gutters, genhtml) expects, since absolute paths break when
-   * `lcov.info` is moved between machines or uploaded from CI. Cross-origin
-   * entries — or entries whose URL parses awkwardly — fall back to the URL
-   * verbatim so the record stays unambiguous.
+   * Map a V8 entry URL to the `SF:` value for its lcov record: a filesystem
+   * path **relative to `sourceRoot`** — the convention every major lcov
+   * consumer expects, since absolute paths break when `lcov.info` is moved
+   * between machines or uploaded from CI.
+   *
+   * Entries reaching this function are always same-origin with `baseUrl`:
+   * `#filterAndMerge` only retains entries whose URLs are in the goal-URL
+   * set, and goal URLs are constructed from `coverageGoals` keys (relative
+   * paths) resolved against `baseUrl`.
    */
-  static #sourceFile(url, origin, sourceRoot) {
-    if (!origin || !sourceRoot) {
-      return url;
-    }
-    let parsed;
-    try {
-      parsed = new URL(url);
-    } catch {
-      return url;
-    }
-    if (parsed.origin !== origin) {
-      return url;
-    }
+  static #sourceFile(url, sourceRoot) {
     // Decode %xx escapes so on-disk filenames match, then strip the leading
     //  `/` so the path joins cleanly under `sourceRoot`.
-    const decoded = decodeURIComponent(parsed.pathname).replace(/^\/+/, '');
+    const decoded = decodeURIComponent(new URL(url).pathname).replace(/^\/+/, '');
     return relativePath(sourceRoot, resolvePath(sourceRoot, decoded));
   }
 }

--- a/x-test-cli.js
+++ b/x-test-cli.js
@@ -36,11 +36,12 @@ x-test — run TAP-compliant browser tests from the command line
                                 (required, or set in x-test.config.js)
 
   OPTIONS
-    --coverage <boolean>        Collect JS coverage via Chromium DevTools. Compares
-                                against goals defined in the config file and emits a
-                                diagnostic block after the run. Exits non-zero if a goal is
-                                not met. See “COVERAGE” below. Default: false.
-                                Only supported with chromium-based clients.
+    --coverage <boolean>        Collect JS and CSS coverage via Chromium DevTools.
+                                Compares against goals defined in the config file
+                                and emits a diagnostic block after the run. Exits
+                                non-zero if a goal is not met. See “COVERAGE”
+                                below. Default: false. Only supported with
+                                chromium-based clients.
 
     --root <path>               Resource root of the URL origin — the directory the
                                 dev server serves at “/”. Used to resolve
@@ -89,8 +90,14 @@ x-test — run TAP-compliant browser tests from the command line
     auto-disabled when “--name-pattern” is set — the numbers would only
     reflect the filtered subset of tests and misgrade the goals.
 
+    The “coverageGoals” keys may target either JS or CSS files (or any path
+    served by the dev server); the same { lines } axis applies to both.
+    JS coverage comes from V8; CSS coverage comes from Chromium’s
+    rule-usage tracker — both are reported as line percentages.
+
     The following pragmas (matching “node:coverage” patterns) are
-    available and will be adhered to during coverage assessment:
+    available and will be adhered to during coverage assessment.
+    Block-comment syntax means they apply to JS and CSS alike:
 
       /* x-test:coverage disable */
       // ... region omitted from the report
@@ -347,14 +354,13 @@ try {
 let coverageOk = true;
 if (coverage && rawCoverageEntries && tap.result.ok) {
   try {
-    const origin = new URL(url).origin;
     // Synthesize entries for goal files the browser never loaded but that
     //  exist on disk — so the summary shows `0.0 / goal  not ok` with a real
     //  denominator and lcov shows the file all-red, rather than a terse
     //  “missing” notation.
     const synthetic = await XTestCliCoverage.synthesizeMissingEntries({
       entries: rawCoverageEntries,
-      origin,
+      baseUrl,
       sourceRoot,
       goals:   options.coverageGoals,
     });
@@ -362,13 +368,13 @@ if (coverage && rawCoverageEntries && tap.result.ok) {
     await XTestCliCoverage.writeLcov({
       entries: allEntries,
       outDir:  './coverage',
-      origin,                          // In-origin entries map to on-disk paths.
+      baseUrl,                         // In-origin entries map to on-disk paths.
       sourceRoot,
       goals:   options.coverageGoals,  // Only goal files appear in lcov.
     });
     const graded = XTestCliCoverage.gradeCoverage({
       entries: allEntries,
-      origin,
+      baseUrl,
       goals:   options.coverageGoals,
     });
     coverageOk = graded.ok;

--- a/x-test.config.js
+++ b/x-test.config.js
@@ -3,6 +3,14 @@ export default {
   coverageGoals: {
     // Dummy module under test — imported by `test/browser/main.js`,
     //  exercised partially so the summary shows a meaningful number.
-    './test/browser/subject.js': { lines: 50 },
+    './test/browser/subject.js':  { lines: 50 },
+    // Linked stylesheet — applied via `<link>` in index.html. One rule
+    //  matches the page's `<h1>`, one does not. Comment-only lines are
+    //  stripped from the denominator (see `#cssCommentMask`), so the
+    //  natural shape is "matched-rule lines / all-rule lines" = 50%.
+    './test/browser/index.css':   { lines: 50 },
+    // CSS module script — imported with `type: 'css'` and adopted onto
+    //  the document by subject.js. Same partial-coverage shape.
+    './test/browser/subject.css': { lines: 50 },
   },
 };


### PR DESCRIPTION
By simply starting CSS coverage alongside JS coverage by default, we can keep our current interface _exactly_. Now, if a developer adds a file that happens to be CSS — it _just works_.

Note that we need to manually ignore CSS comments [for reasons] as they are not reported as _seen_ by the CSS coverage tools today.

Closes #29.

<img width="1141" height="1006" alt="Screenshot 2026-04-28 at 9 11 10 PM" src="https://github.com/user-attachments/assets/dd0ee854-3337-4980-9194-2372926f2171" />
