### PR TITLE
Tighten config validation.

### DIFF
--- a/test/node/config.test.js
+++ b/test/node/config.test.js
@@ -62,95 +62,97 @@ suite('XTestCliConfig.load', () => {
   });
 });
 
-suite('XTestCliConfig.validateRoot', () => {
-  test('undefined is a no-op', () => {
-    XTestCliConfig.validateRoot(undefined);
+suite('XTestCliConfig.validateConfig — root', () => {
+  test('absent is a no-op', () => {
+    XTestCliConfig.validateConfig({});
   });
 
   test('relative-prefixed strings pass', () => {
-    XTestCliConfig.validateRoot('./public');
-    XTestCliConfig.validateRoot('../sibling/dist');
+    XTestCliConfig.validateConfig({ root: './public' });
+    XTestCliConfig.validateConfig({ root: '../sibling/dist' });
   });
 
   test('empty string rejected', () => {
-    assert.throws(() => XTestCliConfig.validateRoot(''), /non-empty string/);
+    assert.throws(() => XTestCliConfig.validateConfig({ root: '' }), /non-empty string/);
   });
 
   test('absolute and bare paths rejected', () => {
     // Bare ("public") and absolute ("/abs/path") forms are rejected so output
     //  formatting stays uniform with `coverageGoals` keys (Node-style `./`).
-    assert.throws(() => XTestCliConfig.validateRoot('/abs/path'), /relative path/);
-    assert.throws(() => XTestCliConfig.validateRoot('public'),    /relative path/);
+    assert.throws(() => XTestCliConfig.validateConfig({ root: '/abs/path' }), /relative path/);
+    assert.throws(() => XTestCliConfig.validateConfig({ root: 'public' }),    /relative path/);
   });
 
   test('non-string rejected', () => {
-    assert.throws(() => XTestCliConfig.validateRoot(42),    /non-empty string/);
-    assert.throws(() => XTestCliConfig.validateRoot(null),  /non-empty string/);
-    assert.throws(() => XTestCliConfig.validateRoot({}),    /non-empty string/);
+    assert.throws(() => XTestCliConfig.validateConfig({ root: 42 }),   /non-empty string/);
+    assert.throws(() => XTestCliConfig.validateConfig({ root: null }), /non-empty string/);
+    assert.throws(() => XTestCliConfig.validateConfig({ root: {} }),   /non-empty string/);
   });
 });
 
-suite('XTestCliConfig.validateCoverageGoals', () => {
-  test('undefined is a no-op', () => {
-    XTestCliConfig.validateCoverageGoals(undefined);
+suite('XTestCliConfig.validateConfig — coverageGoals', () => {
+  test('absent is a no-op', () => {
+    XTestCliConfig.validateConfig({});
   });
 
   test('valid { lines: N } passes', () => {
-    XTestCliConfig.validateCoverageGoals({
-      './src/a.js': { lines: 100 },
-      './src/b.js': { lines: 0 },
-      './src/c.js': { lines: 50.5 },
+    XTestCliConfig.validateConfig({
+      coverageGoals: {
+        './src/a.js': { lines: 100 },
+        './src/b.js': { lines: 0 },
+        './src/c.js': { lines: 50.5 },
+      },
     });
   });
 
   test('non-object root → throws', () => {
-    assert.throws(() => XTestCliConfig.validateCoverageGoals('nope'), /must be an object/);
-    assert.throws(() => XTestCliConfig.validateCoverageGoals([]), /must be an object/);
-    assert.throws(() => XTestCliConfig.validateCoverageGoals(null), /must be an object/);
+    assert.throws(() => XTestCliConfig.validateConfig({ coverageGoals: 'nope' }), /must be an object/);
+    assert.throws(() => XTestCliConfig.validateConfig({ coverageGoals: [] }),     /must be an object/);
+    assert.throws(() => XTestCliConfig.validateConfig({ coverageGoals: null }),   /must be an object/);
   });
 
   test('non-object entry → throws', () => {
-    assert.throws(() => XTestCliConfig.validateCoverageGoals({ './a.js': 100 }), /must be an object/);
-    assert.throws(() => XTestCliConfig.validateCoverageGoals({ './a.js': null }), /must be an object/);
+    assert.throws(() => XTestCliConfig.validateConfig({ coverageGoals: { './a.js': 100 } }),  /must be an object/);
+    assert.throws(() => XTestCliConfig.validateConfig({ coverageGoals: { './a.js': null } }), /must be an object/);
   });
 
   test('branches/functions/statements → not yet supported', () => {
     assert.throws(
-      () => XTestCliConfig.validateCoverageGoals({ './a.js': { branches: 50 } }),
+      () => XTestCliConfig.validateConfig({ coverageGoals: { './a.js': { branches: 50 } } }),
       /'branches' not yet supported/,
     );
     assert.throws(
-      () => XTestCliConfig.validateCoverageGoals({ './a.js': { functions: 90 } }),
+      () => XTestCliConfig.validateConfig({ coverageGoals: { './a.js': { functions: 90 } } }),
       /'functions' not yet supported/,
     );
     assert.throws(
-      () => XTestCliConfig.validateCoverageGoals({ './a.js': { statements: 80 } }),
+      () => XTestCliConfig.validateConfig({ coverageGoals: { './a.js': { statements: 80 } } }),
       /'statements' not yet supported/,
     );
   });
 
   test('unknown axis → throws with "unknown axis"', () => {
     assert.throws(
-      () => XTestCliConfig.validateCoverageGoals({ './a.js': { nonsense: 50 } }),
+      () => XTestCliConfig.validateConfig({ coverageGoals: { './a.js': { nonsense: 50 } } }),
       /unknown axis/,
     );
   });
 
   test('lines out of range → throws', () => {
     assert.throws(
-      () => XTestCliConfig.validateCoverageGoals({ './a.js': { lines: 150 } }),
+      () => XTestCliConfig.validateConfig({ coverageGoals: { './a.js': { lines: 150 } } }),
       /must be a number in \[0, 100\]/,
     );
     assert.throws(
-      () => XTestCliConfig.validateCoverageGoals({ './a.js': { lines: -1 } }),
+      () => XTestCliConfig.validateConfig({ coverageGoals: { './a.js': { lines: -1 } } }),
       /must be a number in \[0, 100\]/,
     );
     assert.throws(
-      () => XTestCliConfig.validateCoverageGoals({ './a.js': { lines: 'high' } }),
+      () => XTestCliConfig.validateConfig({ coverageGoals: { './a.js': { lines: 'high' } } }),
       /must be a number/,
     );
     assert.throws(
-      () => XTestCliConfig.validateCoverageGoals({ './a.js': {} }),
+      () => XTestCliConfig.validateConfig({ coverageGoals: { './a.js': {} } }),
       /must be a number/,
     );
   });
@@ -159,14 +161,210 @@ suite('XTestCliConfig.validateCoverageGoals', () => {
     // Bare (`a.js`) and absolute (`/a.js`) keys are rejected so the coverage
     //  table renders Node-style relative paths uniformly with `root`.
     assert.throws(
-      () => XTestCliConfig.validateCoverageGoals({ 'a.js': { lines: 50 } }),
+      () => XTestCliConfig.validateConfig({ coverageGoals: { 'a.js': { lines: 50 } } }),
       /relative path/,
     );
     assert.throws(
-      () => XTestCliConfig.validateCoverageGoals({ '/a.js': { lines: 50 } }),
+      () => XTestCliConfig.validateConfig({ coverageGoals: { '/a.js': { lines: 50 } } }),
       /relative path/,
     );
-    XTestCliConfig.validateCoverageGoals({ './a.js':  { lines: 50 } });
-    XTestCliConfig.validateCoverageGoals({ '../b.js': { lines: 50 } });
+    XTestCliConfig.validateConfig({ coverageGoals: { './a.js':  { lines: 50 } } });
+    XTestCliConfig.validateConfig({ coverageGoals: { '../b.js': { lines: 50 } } });
+  });
+});
+
+suite('XTestCliConfig.validateConfig — top-level shape', () => {
+  test('unknown keys throw', () => {
+    assert.throws(
+      () => XTestCliConfig.validateConfig({ coverageGoal: {} }),
+      /Unknown config key "coverageGoal"/,
+    );
+    assert.throws(
+      () => XTestCliConfig.validateConfig({ foo: 1 }),
+      /Unknown config key "foo"/,
+    );
+  });
+
+  test('non-object input throws', () => {
+    assert.throws(() => XTestCliConfig.validateConfig(null),  /must be an object/);
+    assert.throws(() => XTestCliConfig.validateConfig([]),    /must be an object/);
+    assert.throws(() => XTestCliConfig.validateConfig('hi'),  /must be an object/);
+  });
+
+  test('client/browser/reporter enums', () => {
+    XTestCliConfig.validateConfig({ client: 'puppeteer' });
+    XTestCliConfig.validateConfig({ client: 'playwright' });
+    XTestCliConfig.validateConfig({ browser: 'chromium' });
+    XTestCliConfig.validateConfig({ reporter: 'tap' });
+    XTestCliConfig.validateConfig({ reporter: 'auto' });
+    assert.throws(() => XTestCliConfig.validateConfig({ client:   'bogus' }),  /must be one of/);
+    assert.throws(() => XTestCliConfig.validateConfig({ browser:  'firefox' }), /must be one of/);
+    assert.throws(() => XTestCliConfig.validateConfig({ reporter: 'spec' }),    /must be one of/);
+  });
+
+  test('coverage must be a real boolean', () => {
+    XTestCliConfig.validateConfig({ coverage: true });
+    XTestCliConfig.validateConfig({ coverage: false });
+    assert.throws(() => XTestCliConfig.validateConfig({ coverage: 'true' }), /must be a boolean/);
+    assert.throws(() => XTestCliConfig.validateConfig({ coverage: 1 }),      /must be a boolean/);
+  });
+
+  test('timeout must be a positive finite number', () => {
+    XTestCliConfig.validateConfig({ timeout: 1 });
+    XTestCliConfig.validateConfig({ timeout: 30_000 });
+    assert.throws(() => XTestCliConfig.validateConfig({ timeout: 0 }),       /positive finite number/);
+    assert.throws(() => XTestCliConfig.validateConfig({ timeout: -1 }),      /positive finite number/);
+    assert.throws(() => XTestCliConfig.validateConfig({ timeout: '30000' }), /positive finite number/);
+    assert.throws(() => XTestCliConfig.validateConfig({ timeout: Infinity }),/positive finite number/);
+  });
+
+  test('url must be a parseable URL string', () => {
+    XTestCliConfig.validateConfig({ url: 'http://localhost:8080/test/' });
+    assert.throws(() => XTestCliConfig.validateConfig({ url: 'not a url' }), /valid URL/);
+    assert.throws(() => XTestCliConfig.validateConfig({ url: '' }),          /non-empty string/);
+  });
+});
+
+suite('XTestCliConfig.parseCli', () => {
+  test('kebab-case keys → camelCase', () => {
+    const opts = XTestCliConfig.parseCli(['--name-pattern=foo', '--client=puppeteer']);
+    assert(opts.namePattern === 'foo');
+    assert(opts.client === 'puppeteer');
+  });
+
+  test('non--- arg throws', () => {
+    assert.throws(() => XTestCliConfig.parseCli(['bare']), /must start with "--"/);
+  });
+
+  test('flag without value throws', () => {
+    assert.throws(() => XTestCliConfig.parseCli(['--client']), /requires a value/);
+  });
+});
+
+suite('XTestCliConfig.validateCli', () => {
+  test('unknown flags throw with kebab-case in message', () => {
+    assert.throws(() => XTestCliConfig.validateCli({ foo: 'x' }),         /Unknown argument "--foo"/);
+    assert.throws(() => XTestCliConfig.validateCli({ coverageGoals: {} }), /Unknown argument "--coverage-goals"/);
+  });
+
+  test('values are strings; coverage must be "true"/"false"', () => {
+    XTestCliConfig.validateCli({ coverage: 'true' });
+    XTestCliConfig.validateCli({ coverage: 'false' });
+    assert.throws(() => XTestCliConfig.validateCli({ coverage: 'maybe' }), /must be "true" or "false"/);
+  });
+
+  test('timeout parses string', () => {
+    XTestCliConfig.validateCli({ timeout: '30000' });
+    assert.throws(() => XTestCliConfig.validateCli({ timeout: '-5' }), /positive number/);
+    assert.throws(() => XTestCliConfig.validateCli({ timeout: 'abc' }), /positive number/);
+  });
+
+  test('client/browser/reporter enums', () => {
+    assert.throws(() => XTestCliConfig.validateCli({ client:   'bogus' }),    /must be one of/);
+    assert.throws(() => XTestCliConfig.validateCli({ browser:  'firefox' }),  /must be one of/);
+    assert.throws(() => XTestCliConfig.validateCli({ reporter: 'spec' }),     /must be one of/);
+    XTestCliConfig.validateCli({ browser: 'chromium' });
+  });
+});
+
+suite('XTestCliConfig.resolve', () => {
+  const baseArgs = { cwd: '/tmp/x', env: {}, isTTY: false };
+
+  test('CLI overrides config', () => {
+    const r = XTestCliConfig.resolve({
+      ...baseArgs,
+      config: { client: 'playwright', url: 'http://a/' },
+      cli:    { client: 'puppeteer' },
+    });
+    assert(r.client === 'puppeteer');
+    assert(r.url === 'http://a/');
+  });
+
+  test('missing client/url throws', () => {
+    assert.throws(
+      () => XTestCliConfig.resolve({ ...baseArgs, config: {}, cli: { url: 'http://a/' } }),
+      /"--client" is required/,
+    );
+    assert.throws(
+      () => XTestCliConfig.resolve({ ...baseArgs, config: {}, cli: { client: 'puppeteer' } }),
+      /"--url" is required/,
+    );
+  });
+
+  test('coverage=true without coverageGoals throws', () => {
+    assert.throws(
+      () => XTestCliConfig.resolve({
+        ...baseArgs,
+        config: { coverage: true },
+        cli:    { client: 'puppeteer', url: 'http://a/' },
+      }),
+      /requires coverageGoals/,
+    );
+  });
+
+  test('namePattern disables coverage and is injected into URL', () => {
+    const r = XTestCliConfig.resolve({
+      ...baseArgs,
+      config: { coverage: true, coverageGoals: { './a.js': { lines: 50 } } },
+      cli:    { client: 'puppeteer', url: 'http://a/test/', namePattern: 'foo' },
+    });
+    assert(r.coverage === false);
+    assert(r.coverageDisabledByPattern === true);
+    assert(/x-test-name-pattern=foo/.test(r.url));
+  });
+
+  test('CLI string coverage parses to boolean', () => {
+    const t = XTestCliConfig.resolve({
+      ...baseArgs,
+      config: { coverageGoals: { './a.js': { lines: 50 } } },
+      cli:    { client: 'puppeteer', url: 'http://a/', coverage: 'true' },
+    });
+    assert(t.coverage === true);
+    const f = XTestCliConfig.resolve({
+      ...baseArgs,
+      config: {},
+      cli:    { client: 'puppeteer', url: 'http://a/', coverage: 'false' },
+    });
+    assert(f.coverage === false);
+  });
+
+  test('reporter=tap forces no color even on TTY', () => {
+    const r = XTestCliConfig.resolve({
+      cwd: '/tmp/x', env: {}, isTTY: true,
+      config: {}, cli: { client: 'puppeteer', url: 'http://a/', reporter: 'tap' },
+    });
+    assert(r.color === false);
+  });
+
+  test('NO_COLOR suppresses color', () => {
+    const r = XTestCliConfig.resolve({
+      cwd: '/tmp/x', env: { NO_COLOR: '1' }, isTTY: true,
+      config: {}, cli: { client: 'puppeteer', url: 'http://a/' },
+    });
+    assert(r.color === false);
+  });
+
+  test('default timeout is 30_000', () => {
+    const r = XTestCliConfig.resolve({
+      ...baseArgs,
+      config: {}, cli: { client: 'puppeteer', url: 'http://a/' },
+    });
+    assert(r.runTimeout === 30_000);
+  });
+
+  test('CLI timeout string parses to number', () => {
+    const r = XTestCliConfig.resolve({
+      ...baseArgs,
+      config: {}, cli: { client: 'puppeteer', url: 'http://a/', timeout: '5000' },
+    });
+    assert(r.runTimeout === 5000);
+  });
+
+  test('baseUrl is origin + "/"', () => {
+    const r = XTestCliConfig.resolve({
+      ...baseArgs,
+      config: {}, cli: { client: 'puppeteer', url: 'http://localhost:8080/test/sub/' },
+    });
+    assert(r.baseUrl === 'http://localhost:8080/');
   });
 });

--- a/x-test-cli-config.js
+++ b/x-test-cli-config.js
@@ -2,12 +2,24 @@ import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 /**
- * Loads and validates `x-test.config.js`. All methods are static — nothing
- * stateful lives here, just the config filename and the axis-name allowlists
- * that gate `coverageGoals` entries.
+ * Loads, validates, and resolves x-test CLI configuration. The pipeline is
+ *
+ *   1. `parseCli(argv)`            — argv → camelCase string-valued options.
+ *   2. `load(cwd)`                 — read x-test.config.js (object | {}).
+ *   3. `validateConfig(config)`    — strict shape check on the config object.
+ *   4. `validateCli(cli)`          — strict shape check on the CLI options.
+ *   5. `resolve({ config, cli, … })` — merge (CLI > config), default, coerce,
+ *                                     and derive (baseUrl, sourceRoot, color,
+ *                                     name-pattern URL injection) exactly once.
+ *
+ * All methods are static; nothing stateful lives here.
  */
 export class XTestCliConfig {
   static #CONFIG_FILE_NAME = 'x-test.config.js';
+
+  static #SUPPORTED_CLIENTS   = ['puppeteer', 'playwright'];
+  static #SUPPORTED_BROWSERS  = ['chromium'];
+  static #SUPPORTED_REPORTERS = ['tap', 'auto'];
 
   // Axes recognized in `coverageGoals[path]` entries. Only `lines` is graded
   //  in this increment; the other names exist so we can reject them loudly
@@ -20,15 +32,23 @@ export class XTestCliConfig {
   //  bare/absolute/`./`-prefixed paths in their config.
   static #RELATIVE_PREFIXES = ['./', '../'];
 
-  /** Common guard: reject anything that isn't a `./`- or `../`-prefixed string. */
-  static #assertRelative(value, label) {
-    if (typeof value !== 'string' || value === '') {
-      throw new Error(`${label} must be a non-empty string, got ${XTestCliConfig.#describe(value)}.`);
-    }
-    if (!XTestCliConfig.#RELATIVE_PREFIXES.some(p => value.startsWith(p))) {
-      throw new Error(`${label} must be a relative path starting with './' or '../', got ${JSON.stringify(value)}.`);
-    }
-  }
+  // Strict allowlists. Unknown keys throw rather than no-op so typos like
+  //  `coverageGoal` fail loud at startup instead of silently disabling
+  //  coverage grading.
+  static #CONFIG_KEYS = [
+    'url', 'root', 'client', 'browser', 'timeout',
+    'coverage', 'coverageGoals', 'namePattern', 'reporter',
+  ];
+
+  // CLI flags allowed on the command line (camelCase form). `coverageGoals`
+  //  is config-only — too unwieldy to express as a flag value.
+  static #CLI_KEYS = [
+    'url', 'root', 'client', 'browser', 'timeout',
+    'coverage', 'namePattern', 'reporter',
+  ];
+
+  static #DEFAULT_TIMEOUT  = 30_000;
+  static #DEFAULT_REPORTER = 'auto';
 
   /**
    * Load `x-test.config.js` from `cwd`. Returns the module's default export,
@@ -49,27 +69,202 @@ export class XTestCliConfig {
   }
 
   /**
-   * Validate `root` — the disk directory the dev server serves as its root.
-   * Used both to resolve `coverageGoals` keys against disk and to rewrite
-   * stack-trace URLs in synthesized failure output. Must be a `./`- or
-   * `../`-prefixed string when present; bare names and absolute paths fail
-   * loud so output formatting stays consistent across consumers.
+   * Parse `process.argv.slice(2)` into a camelCase options object. Syntactic
+   * checks only (must be `--key=value`, kebab→camel for the key); allowlist
+   * and value-shape checks live in `validateCli`. `--help` and `--version`
+   * are intercepted by the entry script before this is called.
    */
-  static validateRoot(root) {
-    if (root === undefined) {
-      return;
+  static parseCli(argv) {
+    const options = {};
+    for (const arg of argv) {
+      if (!arg.startsWith('--')) {
+        throw new Error(`Invalid argument "${arg}". All arguments must start with "--".`);
+      }
+      const [key, value] = arg.slice(2).split('=', 2);
+      if (value === undefined) {
+        throw new Error(`Argument "--${key}" requires a value (e.g., "--${key}=<value>").`);
+      }
+      // kebab-case flag → camelCase internal key, e.g. `name-pattern` → `namePattern`.
+      const camelKey = key.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+      options[camelKey] = value;
     }
-    XTestCliConfig.#assertRelative(root, 'root');
+    return options;
   }
 
   /**
-   * Validate `coverageGoals` shape. Throws with a path-qualified message on
-   * the first problem found. Keys must be `./`- or `../`-prefixed paths;
-   * values accept only `{ lines: <number 0..100> }`. Unknown axes throw "not
-   * yet supported" so future additions are a deliberate choice, not a silent
-   * config drift.
+   * Validate the parsed `x-test.config.js` default export. Throws on the
+   * first problem found. Empty/missing config (`{}`) is accepted.
    */
-  static validateCoverageGoals(goals) {
+  static validateConfig(config) {
+    if (config === null || typeof config !== 'object' || Array.isArray(config)) {
+      throw new Error(`x-test.config.js default export must be an object, got ${XTestCliConfig.#describe(config)}.`);
+    }
+    for (const key of Object.keys(config)) {
+      if (!XTestCliConfig.#CONFIG_KEYS.includes(key)) {
+        const allowed = XTestCliConfig.#CONFIG_KEYS.map(k => `"${k}"`).join(', ');
+        throw new Error(`Unknown config key "${key}" in x-test.config.js. Allowed: ${allowed}.`);
+      }
+    }
+    if (config.url !== undefined) {
+      XTestCliConfig.#assertUrl(config.url, 'config.url');
+    }
+    if (config.root !== undefined) {
+      XTestCliConfig.#assertRelative(config.root, 'config.root');
+    }
+    if (config.client !== undefined) {
+      XTestCliConfig.#assertEnum(config.client, XTestCliConfig.#SUPPORTED_CLIENTS, 'config.client');
+    }
+    if (config.browser !== undefined) {
+      XTestCliConfig.#assertEnum(config.browser, XTestCliConfig.#SUPPORTED_BROWSERS, 'config.browser');
+    }
+    if (config.timeout !== undefined) {
+      if (typeof config.timeout !== 'number' || !Number.isFinite(config.timeout) || config.timeout <= 0) {
+        throw new Error(`config.timeout must be a positive finite number, got ${XTestCliConfig.#describe(config.timeout)}.`);
+      }
+    }
+    if (config.coverage !== undefined && typeof config.coverage !== 'boolean') {
+      throw new Error(`config.coverage must be a boolean, got ${XTestCliConfig.#describe(config.coverage)}.`);
+    }
+    if (config.namePattern !== undefined) {
+      if (typeof config.namePattern !== 'string' || config.namePattern === '') {
+        throw new Error(`config.namePattern must be a non-empty string, got ${XTestCliConfig.#describe(config.namePattern)}.`);
+      }
+    }
+    if (config.reporter !== undefined) {
+      XTestCliConfig.#assertEnum(config.reporter, XTestCliConfig.#SUPPORTED_REPORTERS, 'config.reporter');
+    }
+    XTestCliConfig.#validateCoverageGoals(config.coverageGoals);
+  }
+
+  /**
+   * Validate the parsed CLI options. All values are strings (since they come
+   * from `--key=value`); boolean/number coercion happens in `resolve`, not
+   * here.
+   */
+  static validateCli(cli) {
+    for (const key of Object.keys(cli)) {
+      if (!XTestCliConfig.#CLI_KEYS.includes(key)) {
+        const allowed = XTestCliConfig.#CLI_KEYS.map(k => `"--${XTestCliConfig.#kebab(k)}"`).join(', ');
+        throw new Error(`Unknown argument "--${XTestCliConfig.#kebab(key)}". Allowed: ${allowed}.`);
+      }
+    }
+    if (cli.url !== undefined) {
+      XTestCliConfig.#assertUrl(cli.url, '--url');
+    }
+    if (cli.root !== undefined) {
+      XTestCliConfig.#assertRelative(cli.root, '--root');
+    }
+    if (cli.client !== undefined) {
+      XTestCliConfig.#assertEnum(cli.client, XTestCliConfig.#SUPPORTED_CLIENTS, '--client');
+    }
+    if (cli.browser !== undefined) {
+      XTestCliConfig.#assertEnum(cli.browser, XTestCliConfig.#SUPPORTED_BROWSERS, '--browser');
+    }
+    if (cli.timeout !== undefined) {
+      const parsed = Number(cli.timeout);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error(`--timeout must be a positive number of milliseconds, got "${cli.timeout}".`);
+      }
+    }
+    if (cli.coverage !== undefined && cli.coverage !== 'true' && cli.coverage !== 'false') {
+      throw new Error(`--coverage must be "true" or "false", got "${cli.coverage}".`);
+    }
+    if (cli.namePattern !== undefined && cli.namePattern === '') {
+      throw new Error('--name-pattern must be a non-empty string.');
+    }
+    if (cli.reporter !== undefined) {
+      XTestCliConfig.#assertEnum(cli.reporter, XTestCliConfig.#SUPPORTED_REPORTERS, '--reporter');
+    }
+  }
+
+  /**
+   * Merge config and CLI (CLI wins) and produce a fully-resolved options
+   * object. Defaults, type coercions, and derived values (`baseUrl`,
+   * `sourceRoot`, `color`, name-pattern URL injection) are applied here
+   * exactly once. Cross-field invariants (`coverage=true ⇒ coverageGoals`,
+   * `--name-pattern ⇒ coverage off`) are enforced here too.
+   */
+  static resolve({ config, cli, cwd, env, isTTY }) {
+    const client = cli.client ?? config.client;
+    if (!client) {
+      throw new Error('"--client" is required (e.g., "--client=puppeteer").');
+    }
+    const rawUrl = cli.url ?? config.url;
+    if (!rawUrl) {
+      throw new Error('"--url" is required (e.g., "--url=http://localhost:8080/test/").');
+    }
+
+    const browser      = cli.browser     ?? config.browser;
+    const namePattern  = cli.namePattern ?? config.namePattern;
+    const root         = cli.root        ?? config.root        ?? '.';
+    const reporterMode = cli.reporter    ?? config.reporter    ?? XTestCliConfig.#DEFAULT_REPORTER;
+
+    // Coverage: CLI is "true"/"false" string, config is real boolean.
+    let coverage;
+    if (cli.coverage !== undefined) {
+      coverage = cli.coverage === 'true';
+    } else if (config.coverage !== undefined) {
+      coverage = config.coverage;
+    } else {
+      coverage = false;
+    }
+    const coverageGoals = config.coverageGoals;
+    if (coverage && !coverageGoals) {
+      throw new Error('--coverage=true requires coverageGoals in x-test.config.js.');
+    }
+    // Coverage is a full-run metric — auto-disable when filtering by name and
+    //  surface the fact via a flag so the entry script can warn the user.
+    let coverageDisabledByPattern = false;
+    if (coverage && namePattern) {
+      coverage = false;
+      coverageDisabledByPattern = true;
+    }
+
+    let runTimeout;
+    if (cli.timeout !== undefined) {
+      runTimeout = Number(cli.timeout);
+    } else if (config.timeout !== undefined) {
+      runTimeout = config.timeout;
+    } else {
+      runTimeout = XTestCliConfig.#DEFAULT_TIMEOUT;
+    }
+
+    // Apply the name-pattern as a search param on the test URL exactly once.
+    const targetUrl = new URL(rawUrl);
+    if (namePattern) {
+      targetUrl.searchParams.set('x-test-name-pattern', namePattern);
+    }
+    const baseUrl    = targetUrl.origin + '/';
+    const sourceRoot = resolve(cwd, root) + '/';
+
+    // Color resolution. Precedence (highest first):
+    //   1. `--reporter=tap`         → forces raw (explicit user intent).
+    //   2. `NO_COLOR`               → https://no-color.org
+    //   3. `FORCE_COLOR`            → ecosystem de facto.
+    //   4. TTY detection on stdout.
+    const suppressColor = reporterMode === 'tap' || env.NO_COLOR;
+    const forceColor    = env.FORCE_COLOR || isTTY;
+    const color         = !suppressColor && !!forceColor;
+
+    return {
+      client,                     // 'puppeteer' | 'playwright'
+      browser,                    // 'chromium' | undefined
+      url: targetUrl.href,        // includes ?x-test-name-pattern when set
+      coverage,                   // boolean, false when namePattern present
+      coverageGoals,              // object | undefined
+      coverageDisabledByPattern,  // true when namePattern overrode coverage
+      namePattern,                // string | undefined
+      runTimeout,                 // number, ms
+      reporterMode,               // 'tap' | 'auto'
+      color,                      // boolean
+      baseUrl,                    // origin + '/'
+      sourceRoot,                 // absolute dir + '/'
+      cwd: cwd + '/',
+    };
+  }
+
+  /** Validate the `coverageGoals` sub-object. See class doc for shape. */
+  static #validateCoverageGoals(goals) {
     if (goals === undefined) {
       return;
     }
@@ -94,6 +289,41 @@ export class XTestCliConfig {
         throw new Error(`coverageGoals[${JSON.stringify(path)}].lines must be a number in [0, 100], got ${XTestCliConfig.#describe(lines)}.`);
       }
     }
+  }
+
+  /** Common guard: reject anything that isn't a `./`- or `../`-prefixed string. */
+  static #assertRelative(value, label) {
+    if (typeof value !== 'string' || value === '') {
+      throw new Error(`${label} must be a non-empty string, got ${XTestCliConfig.#describe(value)}.`);
+    }
+    if (!XTestCliConfig.#RELATIVE_PREFIXES.some(p => value.startsWith(p))) {
+      throw new Error(`${label} must be a relative path starting with './' or '../', got ${JSON.stringify(value)}.`);
+    }
+  }
+
+  /** Common guard: reject anything that isn't a parseable URL string. */
+  static #assertUrl(value, label) {
+    if (typeof value !== 'string' || value === '') {
+      throw new Error(`${label} must be a non-empty string, got ${XTestCliConfig.#describe(value)}.`);
+    }
+    try {
+      new URL(value);
+    } catch {
+      throw new Error(`${label} must be a valid URL, got ${JSON.stringify(value)}.`);
+    }
+  }
+
+  /** Common guard: reject anything not in the given allowlist. */
+  static #assertEnum(value, allowed, label) {
+    if (!allowed.includes(value)) {
+      const list = allowed.map(v => `"${v}"`).join(', ');
+      throw new Error(`${label} must be one of ${list}, got ${JSON.stringify(value)}.`);
+    }
+  }
+
+  /** camelCase → kebab-case for friendly CLI error messages. */
+  static #kebab(camel) {
+    return camel.replace(/[A-Z]/g, c => '-' + c.toLowerCase());
   }
 
   /** Human-readable type description for error messages. */

--- a/x-test-cli.js
+++ b/x-test-cli.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 
 import { XTestCliBrowserPuppeteer, XTestCliBrowserPlaywright } from './x-test-cli-browser.js';
 import { XTestCliTap } from './x-test-cli-tap.js';
@@ -10,16 +9,8 @@ import { XTestCliCoverage } from './x-test-cli-coverage.js';
 
 const cwd = process.cwd();
 
-const SUPPORTED_CLIENTS = ['puppeteer', 'playwright'];
-const SUPPORTED_REPORTERS = ['tap', 'auto'];
-
-// Value-taking flags (always `--key=value`). `--help` and `--version` are
-//  handled as bare flags in the early-exit block below, so they’re not here.
-const ALLOWED_ARGS = ['client', 'url', 'root', 'coverage', 'name-pattern', 'reporter', 'timeout'];
-const ALLOWED_ARGS_DEBUG = ALLOWED_ARGS.map(arg => `"--${arg}"`).join(', ');
-
 const HELP = `\
-x-test — run TAP-compliant browser tests from the command line                                                                                                                           
+x-test — run TAP-compliant browser tests from the command line
 
   USAGE
     x-test --url=<url> --client=<name> --browser=<name> [options]
@@ -31,8 +22,7 @@ x-test — run TAP-compliant browser tests from the command line
     --client <name>             Browser automation client. One of: puppeteer, playwright.
                                 (required, or set in x-test.config.js)
 
-    --browser <name>            Browser to launch. One of: chromium, firefox, webkit.
-                                puppeteer supports chromium only.
+    --browser <name>            Browser to launch. Currently only “chromium”.
                                 (required, or set in x-test.config.js)
 
   OPTIONS
@@ -51,11 +41,10 @@ x-test — run TAP-compliant browser tests from the command line
     --name-pattern <regex>      Regex pattern to filter tests by name. Tests whose
                                 full path (file > describe > … > it) does not
                                 match are skipped.
- 
-    --reporter <name>           Output format. One of: tap, spec, auto. Default: auto.
+
+    --reporter <name>           Output format. One of: tap, auto. Default: auto.
                                   tap  — raw TAP (machine-readable, CI-safe).
-                                  spec — colorized, human-readable summary.
-                                  auto — spec if stdout is a TTY, tap otherwise.
+                                  auto — colorized when stdout is a TTY, tap otherwise.
 
     --timeout <ms>              Per-test-file load timeout. Default: 30000.
 
@@ -128,7 +117,7 @@ x-test — run TAP-compliant browser tests from the command line
     x-test --name-pattern="render"
 
     # CI matrix example
-    x-test --client=playwright --browser=firefox --reporter=tap
+    x-test --client=playwright --browser=chromium --reporter=tap
 
   EXIT CODES
     0   All tests passed (and, if --coverage=true, all goals met).
@@ -139,17 +128,13 @@ x-test — run TAP-compliant browser tests from the command line
     https://github.com/Netflix/x-test
     https://github.com/Netflix/x-test-cli`;
 
-// Exit code 2 is reserved for invocation errors where the request itself is
-//  malformed — distinct from a passing-but-not-ok run (1) or a successful
-//  run (0). Only one path claims it this increment: `--coverage` without
-//  `coverageGoals`. Other invocation errors still use 1 until a later
-//  increment restructures the exit-code surface.
+// Exit code 2 is reserved for invocation errors — the request itself is
+//  malformed. Distinct from 1 (a passing-but-not-ok run) and 0 (success).
 function fail(message, code = 1) {
   console.error(message); // eslint-disable-line no-console
   process.exit(code);
 }
 
-// Parse command line arguments
 const args = process.argv.slice(2);
 
 // Early-exit info flags — match anywhere in argv, ignore everything else,
@@ -165,137 +150,42 @@ if (args.includes('--version')) {
   process.exit(0);
 }
 
-const cliOptions = {};
-
-for (const arg of args) {
-  if (arg.startsWith('--')) {
-    const [key, value] = arg.slice(2).split('=', 2);
-
-    if (!ALLOWED_ARGS.includes(key)) {
-      fail(`Error: Unknown argument "--${key}".\nAllowed arguments: ${ALLOWED_ARGS_DEBUG}.`);
-    }
-
-    if (value === undefined) {
-      fail(`Error: Argument "--${key}" requires a value (e.g., "--${key}=<value>").`);
-    }
-
-    // kebab-case flag → camelCase internal key, e.g. `name-pattern` → `namePattern`.
-    const camelKey = key.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
-    cliOptions[camelKey] = value;
-  } else {
-    fail(`Error: Invalid argument "${arg}". All arguments must start with "--".`);
-  }
-}
-
-// Load `x-test.config.js` from cwd if present; empty object otherwise. CLI
-//  flags override config values via the spread order below.
-let configOptions;
+// Validate config, validate CLI, merge (CLI > config), resolve everything once.
+//  Any failure in this block is an invocation error → exit 2.
+let resolved;
 try {
-  configOptions = await XTestCliConfig.load(cwd);
-} catch (error) {
-  fail(`Error: failed to load x-test.config.js: ${error.message}`);
-}
-const options = { ...configOptions, ...cliOptions };
-
-if (!options.client) {
-  fail('Error: "--client" is required (e.g., "--client=puppeteer").');
-}
-
-if (!options.url) {
-  fail('Error: "--url" is required (e.g., "--url=http://localhost:8080/test/").');
-}
-
-if (!SUPPORTED_CLIENTS.includes(options.client)) {
-  const supported = SUPPORTED_CLIENTS.map(client => `"${client}"`).join(', ');
-  fail(`Error: Unsupported client "${options.client}". Supported clients: ${supported}.`);
-}
-
-// Coverage flag. CLI flags arrive as strings; config may set a real boolean.
-//  Either is accepted.
-let coverage = false;
-if (options.coverage === true || options.coverage === 'true') {
-  coverage = true;
-} else if (options.coverage !== undefined && options.coverage !== false && options.coverage !== 'false') {
-  fail(`Error: --coverage must be "true" or "false", got "${options.coverage}".`);
-}
-
-// The `root` argument is validated unconditionally — bare / absolute paths are
-//  config-shape errors regardless of coverage flag. The `coverageGoals` config
-//  only matters with coverage, so it stays gated.
-try {
-  XTestCliConfig.validateRoot(options.root);
+  const cliOptions    = XTestCliConfig.parseCli(args);
+  const configOptions = await XTestCliConfig.load(cwd);
+  XTestCliConfig.validateConfig(configOptions);
+  XTestCliConfig.validateCli(cliOptions);
+  resolved = XTestCliConfig.resolve({
+    config: configOptions,
+    cli:    cliOptions,
+    cwd,
+    env:    process.env,
+    isTTY:  process.stdout.isTTY,
+  });
 } catch (error) {
   fail(`Error: ${error.message}`, 2);
 }
 
-// Declare fully-qualified base url and source root for output mappings. All
-//  three carry trailing `/` per `XTestCliTap`'s constructor contract.
-const baseUrl    = new URL(options.url).origin + '/';
-const sourceRoot = resolve(cwd, options.root ?? '.') + '/';
-
-// Coverage requires goals. Without `coverageGoals` there is nothing to
-//  grade against — treat as an invocation error so misconfiguration fails
-//  loud instead of silently reporting “all ok”.
-if (coverage && !options.coverageGoals) {
-  fail('Error: --coverage=true requires coverageGoals in x-test.config.js.', 2);
-}
-if (coverage) {
-  try {
-    XTestCliConfig.validateCoverageGoals(options.coverageGoals);
-  } catch (error) {
-    fail(`Error: ${error.message}`, 2);
-  }
-}
-
-// Coverage is a full-run metric — numbers are only meaningful when every test
-//  has had a chance to exercise the source. Filtering tests by name would
-//  grade a partial run against full-run goals and produce false misses, so
-//  auto-disable coverage in that case and tell the user.
-if (coverage && options.namePattern) {
+if (resolved.coverageDisabledByPattern) {
   console.warn('Note: --coverage disabled because --name-pattern is set. Coverage requires a full run.'); // eslint-disable-line no-console
-  coverage = false;
 }
-
-// Run timeout (ms). Bounds the handshake with the x-test root so a missing or
-//  broken root can’t hang the CLI forever. Default 30s.
-let runTimeout = 30_000;
-if (options.timeout !== undefined) {
-  const parsed = Number(options.timeout);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    fail(`Error: --timeout must be a positive number of milliseconds, got "${options.timeout}".`);
-  }
-  runTimeout = parsed;
-}
-
-const reporterMode = options.reporter ?? 'auto';
-if (!SUPPORTED_REPORTERS.includes(reporterMode)) {
-  const supported = SUPPORTED_REPORTERS.map(reporter => `"${reporter}"`).join(', ');
-  fail(`Error: Unsupported reporter "${reporterMode}". Supported reporters: ${supported}.`);
-}
-
-// Resolve whether to colorize. Precedence (highest first):
-//   1. `--reporter=tap` forces raw (explicit user intent on this run)
-//   2. `NO_COLOR` env var (https://no-color.org)
-//   3. `FORCE_COLOR` env var (ecosystem de facto)
-//   4. TTY detection on stdout
-const suppressColor = reporterMode === 'tap' || process.env.NO_COLOR;
-const forceColor    = process.env.FORCE_COLOR || process.stdout.isTTY;
-const color         = !suppressColor && !!forceColor;
 
 // Own the TAP reporter here — the driver just emits browser console lines. The
 //  reporter auto-ends when it parses a terminal TAP line (top-level plan
 //  satisfied, or `Bail out!`); we bridge that to the driver via `streamEnded`,
 //  so the driver knows when to stop collecting coverage and close the browser.
 const { promise: streamEnded, resolve: endStream } = Promise.withResolvers();
-const tap = new XTestCliTap({ stream: process.stdout, color, endStream, baseUrl, sourceRoot, cwd: cwd + '/' });
-
-// Resolve the target URL. Apply the name-pattern filter if present.
-let url = options.url;
-if (options.namePattern) {
-  const urlObj = new URL(url);
-  urlObj.searchParams.set('x-test-name-pattern', options.namePattern);
-  url = urlObj.href;
-}
+const tap = new XTestCliTap({
+  stream:     process.stdout,
+  color:      resolved.color,
+  endStream,
+  baseUrl:    resolved.baseUrl,
+  sourceRoot: resolved.sourceRoot,
+  cwd:        resolved.cwd,
+});
 
 // Browser-launch timeout (ms). Applies only to the underlying puppeteer or
 //  playwright `launch()` call — “fail fast if the browser can’t start.” Not a
@@ -306,11 +196,14 @@ const LAUNCH_TIMEOUT_MS = 10_000;
 //  the run. Populated only when `coverage === true`.
 let rawCoverageEntries = null;
 
-const launchTimeout = LAUNCH_TIMEOUT_MS;
-const onConsole = text => tap.write(text);
-const onCoverage = entries => { rawCoverageEntries = entries; };
-const ended = streamEnded;
-const driverOptions = { url, coverage, launchTimeout, onConsole, onCoverage, ended };
+const driverOptions = {
+  url:           resolved.url,
+  coverage:      resolved.coverage,
+  launchTimeout: LAUNCH_TIMEOUT_MS,
+  onConsole:     text    => tap.write(text),
+  onCoverage:    entries => { rawCoverageEntries = entries; },
+  ended:         streamEnded,
+};
 
 // Global run timeout. Races the driver against a timer — covers launch,
 //  navigation, handshake, and coverage uniformly. The losing promise keeps
@@ -328,18 +221,18 @@ function withTimeout(promise, ms, message) {
 //  navigation, etc.) emit `Bail out!` through the reporter so it gets colorized
 //  and the scanner records the bailed state, then dump the error to stderr
 //  (outside the TAP stream) and exit 1.
-const timeoutMessage = `Timed out after ${runTimeout}ms waiting for x-test root at ${url}. Use --timeout=<ms> to extend.`;
+const timeoutMessage = `Timed out after ${resolved.runTimeout}ms waiting for x-test root at ${resolved.url}. Use --timeout=<ms> to extend.`;
 try {
-  switch (options.client) {
+  switch (resolved.client) {
     case 'puppeteer':
-      await withTimeout(XTestCliBrowserPuppeteer.run(driverOptions), runTimeout, timeoutMessage);
+      await withTimeout(XTestCliBrowserPuppeteer.run(driverOptions), resolved.runTimeout, timeoutMessage);
       break;
     case 'playwright':
-      await withTimeout(XTestCliBrowserPlaywright.run(driverOptions), runTimeout, timeoutMessage);
+      await withTimeout(XTestCliBrowserPlaywright.run(driverOptions), resolved.runTimeout, timeoutMessage);
       break;
   }
 } catch (error) {
-  tap.write(`Bail out! The ${options.client} client crashed.`);
+  tap.write(`Bail out! The ${resolved.client} client crashed.`);
   console.error(error); // eslint-disable-line no-console
   process.exit(1);
 }
@@ -352,30 +245,30 @@ try {
 //  layering coverage on top is noise. Coverage is a secondary signal that
 //  only matters once the primary one (test pass/fail) is green.
 let coverageOk = true;
-if (coverage && rawCoverageEntries && tap.result.ok) {
+if (resolved.coverage && rawCoverageEntries && tap.result.ok) {
   try {
     // Synthesize entries for goal files the browser never loaded but that
     //  exist on disk — so the summary shows `0.0 / goal  not ok` with a real
     //  denominator and lcov shows the file all-red, rather than a terse
     //  “missing” notation.
     const synthetic = await XTestCliCoverage.synthesizeMissingEntries({
-      entries: rawCoverageEntries,
-      baseUrl,
-      sourceRoot,
-      goals:   options.coverageGoals,
+      entries:    rawCoverageEntries,
+      baseUrl:    resolved.baseUrl,
+      sourceRoot: resolved.sourceRoot,
+      goals:      resolved.coverageGoals,
     });
     const allEntries = [...rawCoverageEntries, ...synthetic];
     await XTestCliCoverage.writeLcov({
-      entries: allEntries,
-      outDir:  './coverage',
-      baseUrl,                         // In-origin entries map to on-disk paths.
-      sourceRoot,
-      goals:   options.coverageGoals,  // Only goal files appear in lcov.
+      entries:    allEntries,
+      outDir:     './coverage',
+      baseUrl:    resolved.baseUrl,        // In-origin entries map to on-disk paths.
+      sourceRoot: resolved.sourceRoot,
+      goals:      resolved.coverageGoals,  // Only goal files appear in lcov.
     });
     const graded = XTestCliCoverage.gradeCoverage({
       entries: allEntries,
-      baseUrl,
-      goals:   options.coverageGoals,
+      baseUrl: resolved.baseUrl,
+      goals:   resolved.coverageGoals,
     });
     coverageOk = graded.ok;
     tap.writeCoverage(graded.results);


### PR DESCRIPTION
We just need to lock this down ahead of a major release to ensure developers don’t silently misconfigure things.